### PR TITLE
fix: Remove runtime attributes from LaunchScreen

### DIFF
--- a/Projects/App/Resources/Storyboards/Base.lproj/LaunchScreen.storyboard
+++ b/Projects/App/Resources/Storyboards/Base.lproj/LaunchScreen.storyboard
@@ -17,7 +17,20 @@
                     <view key="view" contentMode="scaleToFill" id="05h-oa-cpG">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="SplashIcon" translatesAutoresizingMaskIntoConstraints="NO" id="splash-image-view">
+                                <rect key="frame" x="127.5" y="273.5" width="120" height="120"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="120" id="splash-width"/>
+                                    <constraint firstAttribute="height" constant="120" id="splash-height"/>
+                                </constraints>
+                            </imageView>
+                        </subviews>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="splash-image-view" firstAttribute="centerX" secondItem="05h-oa-cpG" secondAttribute="centerX" id="splash-center-x"/>
+                            <constraint firstItem="splash-image-view" firstAttribute="centerY" secondItem="05h-oa-cpG" secondAttribute="centerY" id="splash-center-y"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="WMI-9s-XU9" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -25,4 +38,7 @@
             <point key="canvasLocation" x="52" y="374.66266866566718"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="SplashIcon" width="512" height="512"/>
+    </resources>
 </document>


### PR DESCRIPTION
Fixes #32

### Summary
Fixed build error by removing user-defined runtime attributes from LaunchScreen.storyboard. Launch screens cannot use runtime attributes like cornerRadius.

### Changes
- Added SplashIcon image to LaunchScreen (120x120, centered)
- Removed all runtime attributes to comply with iOS launch screen requirements
- Image appears square in launch screen, rounded in actual SplashScreen

### Technical Note
Launch screens are rendered before app code executes, so they can only use basic UIKit properties. The corner radius will appear when SplashScreen.swift loads.

Generated with [Claude Code](https://claude.ai/code)