### PR TITLE
fix: AccentColor.colorset 추가하여 asset catalog 경고 해결

### DIFF
--- a/Projects/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Projects/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.016",
+          "green" : "0.006",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "1.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
AccentColor.colorset 을 asset catalog 루트에 추가하여 경고를 해결합니다.

Closes #54

Generated with [Claude Code](https://claude.ai/code)