### PR TITLE
fix: Result of 'try?' is unused ##56

### DIFF
--- a/Projects/App/Sources/Controllers/CoreData/SAModelController.swift
+++ b/Projects/App/Sources/Controllers/CoreData/SAModelController.swift
@@ -65,7 +65,7 @@ class SAModelController : NSObject{
         let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         context.persistentStoreCoordinator = {
             let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
-            try? coordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
+            _ = try? coordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
             
             return coordinator
         }()


### PR DESCRIPTION
Result of 'try?' is unused 경고 수정

- SAModelController.swift:68에서 addPersistentStore 반환값을 _ = 로 명시적으로 무시하여 컴파일 경고 제거

Closes #56

Generated with [Claude Code](https://claude.ai/code)