### PR TITLE
fix: replace deprecated keyWindow with self.window in RewardManager

### DIFF
--- a/Projects/App/Sources/Extensions/GoogleAds/RewardManager.swift
+++ b/Projects/App/Sources/Extensions/GoogleAds/RewardManager.swift
@@ -146,7 +146,7 @@ class GADRewardManager : NSObject{
          alert.dismiss(animated: false, completion: nil);
          }*/
         
-        guard !(UIApplication.shared.keyWindow?.rootViewController?.presentedViewController is UIAlertController) else{
+        guard !(self.window.rootViewController?.presentedViewController is UIAlertController) else{
             //alert.dismiss(animated: false, completion: nil);
             self.rewardAd = nil;
             return;


### PR DESCRIPTION
UIApplication.shared.keyWindow was deprecated in iOS 13.0. GADRewardManager already holds a UIWindow reference as self.window, used everywhere else in the same class. Line 149 was the only spot still reaching for the deprecated API.

Fixes #59

Generated with [Claude Code](https://claude.ai/code)