### PR TITLE
fix: resolve unused variable warning for newSelectedRule

### DIFF
--- a/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
@@ -253,7 +253,7 @@ struct RecipientRuleListScreen: View {
             }
         })
         .onChange(of: selectedRule, { _, newSelectedRule in
-            if let newSelectedRule {
+            if newSelectedRule != nil {
                 return
             }
             


### PR DESCRIPTION
Replace `if let newSelectedRule` with `if newSelectedRule != nil` to eliminate the Swift compiler warning about an unused value definition.

Closes #61

Generated with [Claude Code](https://claude.ai/code)