### PR TITLE
fix: remove unreachable catch blocks in view models

### DIFF
--- a/Projects/App/Sources/ViewModels/RecipientListScreenModel.swift
+++ b/Projects/App/Sources/ViewModels/RecipientListScreenModel.swift
@@ -71,17 +71,13 @@ class SARecipientListScreenModel: RecipientListScreenModel {
     
     func createRule(modelContext: ModelContext, undoManager: UndoManager?) -> RecipientsRule? {
         let newRule = RecipientsRule(title: "New Rule".localized(), enabled: true)
-        
-        do {
-            modelContext.insert(newRule)
-//            undoManager?.registerUndo(withTarget: modelContext) { context in
-//                context.delete(newRule)
-//            }
-//            try modelContext.save()
-        } catch {
-            return nil
-        }
-        
+
+        modelContext.insert(newRule)
+//        undoManager?.registerUndo(withTarget: modelContext) { context in
+//            context.delete(newRule)
+//        }
+//        try modelContext.save()
+
         return newRule
     }
 }

--- a/Projects/App/Sources/ViewModels/RuleFilterScreenModel.swift
+++ b/Projects/App/Sources/ViewModels/RuleFilterScreenModel.swift
@@ -85,12 +85,8 @@ class RuleFilterScreenModel {
         // Update filter values
         filter.all = selectAll
         filter.includes = selectAll ? nil : selectedItems.sorted().joined(separator: ",")
-        
+
         // Save changes
-        do {
-//            try context.save()
-        } catch {
-            print("Failed to save filter:", error)
-        }
+//        try context.save()
     }
 }


### PR DESCRIPTION
### Summary

Fixed Swift compiler warnings about unreachable catch blocks in two view model files.

### Changes

- Removed do-catch block in `RecipientListScreenModel.createRule()` where the throwing code was commented out
- Removed do-catch block in `RuleFilterScreenModel.save()` where the throwing code was commented out

Both files had `try context.save()` statements commented out, making the catch blocks unreachable and generating compiler warnings.

Closes #62

---
Generated with [Claude Code](https://claude.ai/code)