### PR TITLE
fix: add iOS 18.0 deployment target to framework projects

### DIFF
--- a/Projects/DynamicThirdParty/Project.swift
+++ b/Projects/DynamicThirdParty/Project.swift
@@ -14,6 +14,7 @@ let project = Project(
             destinations: .iOS,
             product: .framework,
             bundleId: .appBundleId.appending(".thirdparty.dynamic"),
+            deploymentTargets: .iOS("18.0"),
             dependencies: [.package(product: "SDWebImage", type: .runtime),
                            .package(product: "FirebaseCrashlytics", type: .runtime),
                            .package(product: "FirebaseAnalytics", type: .runtime),

--- a/Projects/ThirdParty/Project.swift
+++ b/Projects/ThirdParty/Project.swift
@@ -24,6 +24,7 @@ let project = Project(
             destinations: .iOS,
             product: .staticFramework,
             bundleId: .appBundleId.appending(".thirdparty"),
+            deploymentTargets: .iOS("18.0"),
             dependencies: [.package(product: "KakaoSDK", type: .runtime),
                            .package(product: "MBProgressHUD", type: .runtime),
                            .package(product: "LSExtensions", type: .runtime),


### PR DESCRIPTION
Fixes the build warning about DynamicThirdParty.framework version mismatch.

## Changes
- Added `deploymentTargets: .iOS("18.0")` to ThirdParty framework
- Added `deploymentTargets: .iOS("18.0")` to DynamicThirdParty framework

This ensures all three projects (App, ThirdParty, DynamicThirdParty) have consistent iOS 18.0 deployment targets.

Fixes #79

---
Generated with [Claude Code](https://claude.ai/code)