### PR TITLE
fix: explicitly discard unused try? result in RuleRepository

### DIFF
--- a/Projects/App/Sources/Repositories/RuleRepository.swift
+++ b/Projects/App/Sources/Repositories/RuleRepository.swift
@@ -28,8 +28,8 @@ class SARuleRepository : RuleRepository {
         let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         context.persistentStoreCoordinator = {
             let coordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
-            try? coordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
-            
+            _ = try? coordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
+
             return coordinator
         }()
         


### PR DESCRIPTION
## Summary

Fixed compiler warning "Result of 'try?' is unused" in `RuleRepository.swift:31` by explicitly discarding the return value.

## Changes

- Added `_ =` before the `try? coordinator.addPersistentStore(...)` call to explicitly indicate that the result is intentionally being discarded

Fixes #80

Generated with [Claude Code](https://claude.ai/code)