### PR TITLE
fix: remove unused viewModel initialization in RuleFilterScreen #Preview

### DIFF
--- a/Projects/App/Sources/Screens/RuleFilterScreen.swift
+++ b/Projects/App/Sources/Screens/RuleFilterScreen.swift
@@ -77,9 +77,7 @@ struct RuleFilterScreen: View {
     
     let filter = RecipientsFilter(target: .job, includes: nil, excludes: nil, all: true)
     container.mainContext.insert(filter)
-    
-    let viewModel = RuleFilterScreenModel(filter: filter)
-    
+
     return NavigationStack {
         RuleFilterScreen(
             filter: filter


### PR DESCRIPTION
RuleFilterScreen.swift의 #Preview 블록에서 사용되지 않는 viewModel 초기화를 제거합니다.

Closes #91

Generated with [Claude Code](https://claude.ai/code)