### PR TITLE
refactor: 수동 scheme 정의 제거하여 자동 생성 scheme 사용

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -95,27 +95,5 @@ let project = Project(
             resources: [],
             dependencies: [.target(name: "App")]
         ),
-    ], schemes: [
-        .scheme(
-            name: "App",
-            shared: true,
-            buildAction: .buildAction(
-                targets: ["App"],
-                postActions: [
-                    .executionAction(
-                        title: "Tuist Inspect Build",
-                        scriptText: "$HOME/.local/share/mise/shims/tuist inspect build",
-                        target: "App"
-                    )
-                ],
-                runPostActionsOnFailure: true
-            ),
-            runAction: .runAction(
-                configuration: "Debug",
-                arguments: .arguments(launchArguments: [
-                    .launchArgument(name: "-FIRAnalyticsDebugEnabled", isEnabled: true)
-                ])
-            )
-        )
     ], resourceSynthesizers: []
 )


### PR DESCRIPTION
## Summary
수동으로 정의한 scheme의 post action이 Tuist 자동 생성 scheme을 덮어쓰는 문제를 해결했습니다.

## 문제
- App scheme을 수동으로 정의하면서 post action 추가
- 이로 인해 Tuist가 자동 생성하는 scheme이 덮어씌워짐
- 필요한 설정들이 누락될 수 있음

## 해결 방법
- 수동 scheme 정의 완전 제거
- Tuist의 자동 scheme 생성 기능 활용
- 필요한 post action은 다른 방식으로 처리 가능

## 변경사항
- `schemes: [...]` 섹션 제거
- Tuist가 기본 설정으로 scheme 자동 생성

## Test plan
- [x] `tuist generate` 성공
- [x] 앱 빌드 및 실행 정상 작동
- [x] 자동 생성된 scheme 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)