### PR TITLE
feat: 전송 완료 후 전면 광고 표시

### DIFF
--- a/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
@@ -272,12 +272,13 @@ struct RecipientRuleListScreen: View {
 					currentBatchIndex = 0
 				} else {
 					let isBatchComplete = presentNextBatch()
-					// 배치 마지막 전송 완료 시에만 카운트 증가 + 리뷰 요청
+					// 배치 마지막 전송 완료 시에만 카운트 증가 + 리뷰 요청 + 전면 광고
 					if isBatchComplete {
 						LSDefaults.increaseMessageSentCount()
 						if reviewManager.canShow {
 							reviewManager.show()
 						}
+						presentFullAdThen {}
 					}
 				}
 
@@ -302,6 +303,7 @@ struct RecipientRuleListScreen: View {
 				if reviewManager.canShow {
 					reviewManager.show()
 				}
+				presentFullAdThen {}
 			}
 			messageComposerState = .unknown
 		}


### PR DESCRIPTION
## Summary
- 일반 전송 성공 후 전면 광고 표시 (SMS 앱에서 복귀 시점)
- 배치 전송 전체 완료 후에만 전면 광고 표시 — 중간 배치마다 광고 없음
- `+` 버튼(새 필터 추가) 및 셀 탭(편집 모드) 광고는 기존 동작 유지

## 광고 위치 변경 이유
사용자가 목표(문자 전송)를 달성한 직후에 광고를 표시하여 심리적 마찰 최소화.
전송 버튼은 핵심 반복 액션이므로 + 버튼 대비 광고 노출 횟수가 대폭 증가.

## Test plan
- [ ] 일반 전송 완료 후 전면 광고 표시 확인
- [ ] 배치 전송 중간 배치에서는 광고 미표시 확인
- [ ] 배치 전송 전체 완료 후 전면 광고 표시 확인
- [ ] 배치 전송 취소 시 광고 미표시 확인
- [ ] + 버튼 및 편집 셀 탭 시 기존 광고 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)