### PR TITLE
fix: deploy CI에 누락된 tuist setup cache 추가

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -68,9 +68,9 @@ jobs:
         run: |
           tuist auth login
 
-      - name: Disable Tuist Caching
+      - name: Setup Tuist Cache
         run: |
-          sed -i '' 's/enableCaching: true/enableCaching: false/' Tuist.swift
+          tuist setup cache
 
       - name: Generate Xcode Project
         run: |


### PR DESCRIPTION
## Summary
- 잘못된 workaround(`enableCaching` 비활성화) 제거
- 근본 원인인 `tuist setup cache` 누락을 수정

## Root Cause
`build-test.yml`에는 `tuist setup cache` 스텝이 있었지만 `deploy-ios.yml`에서 누락되어 CAS `deadlineExceeded` 오류 발생

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)