### PR TITLE
fix: 필터에 맞는 연락처 없음 알럿에서 Continue 버튼 제거

### DIFF
--- a/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
@@ -66,6 +66,7 @@ struct RecipientRuleListScreen: View {
     @State private var showingAlert = false
     @State private var alertMessage = ""
     @State private var showingSettingsAlert = false
+    @State private var showingNoContactsAlert = false
     @State private var viewModel = SARecipientListScreenModel()
     @State private var isEditing = false
     @State private var messageComposerState: MessageComposeState = .unknown
@@ -363,6 +364,11 @@ struct RecipientRuleListScreen: View {
         } message: {
             Text("Permission required to acess contacts for creating recipients list".localized())
         }
+        .alert("Warning".localized(), isPresented: $showingNoContactsAlert) {
+            Button("OK".localized(), role: .cancel) { }
+        } message: {
+            Text("There is no contact matched to the enabled rules".localized())
+        }
         .navigationDestination(item: $selectedRule) { rule in
             RuleDetailScreen(rule: rule)
         }
@@ -424,8 +430,7 @@ struct RecipientRuleListScreen: View {
                         alertMessage = "There is no activated Rules for Reciepients.\nAll Contacts will receive Message.".localized()
                         showingAlert = true
                     case .noContacts:
-                        alertMessage = "There is no contact matched to the enabled rules".localized()
-                        showingAlert = true
+                        showingNoContactsAlert = true
                     case .permissionDenied:
                         showingSettingsAlert = true
                 }


### PR DESCRIPTION
## Summary
- `noContacts` 에러 시 기존 알럿(Continue 버튼 포함)을 재사용하던 문제 수정
- Continue를 누르면 `onSendMessage(allowAll: true)`가 호출되어 전체 연락처로 전송되는 의도치 않은 동작 방지
- dismiss-only 알럿(`showingNoContactsAlert`)으로 분리

## Before / After
| | Before | After |
|--|--|--|
| 필터 매칭 연락처 없음 | Warning + Continue + Cancel | Warning + OK (dismiss only) |

# Result
<img width="376" height="205" alt="스크린샷 2026-02-20 오후 5 18 17" src="https://github.com/user-attachments/assets/60293fff-89b2-419b-943f-9169ebb2c9fb" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)