### PR TITLE
chore: migrate SDWebImage and Firebase to Tuist registry

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -103,3 +103,14 @@ default_modes:
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
 fixed_tools: []
+
+# override of the corresponding setting in serena_config.yml, see the documentation there.
+# If null or missing, the value from the global config is used.
+symbol_info_budget:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:

--- a/Projects/DynamicThirdParty/Project.swift
+++ b/Projects/DynamicThirdParty/Project.swift
@@ -3,10 +3,8 @@ import ProjectDescriptionHelpers
 
 let project = Project(
     name: "DynamicThirdParty",
-    packages: [.remote(url: "https://github.com/SDWebImage/SDWebImage.git",
-                       requirement: .upToNextMajor(from: "5.1.0")),
-               .remote(url: "https://github.com/firebase/firebase-ios-sdk",
-                       requirement: .upToNextMajor(from: "11.8.1")),
+    packages: [        .package(id: "sdwebimage.sdwebimage", from: "5.1.0"),
+                       .package(id: "firebase.firebase-ios-sdk", from: "11.8.1"),
     ],
     targets: [
         .target(

--- a/Tuist.swift
+++ b/Tuist.swift
@@ -7,7 +7,8 @@ let tuist = Tuist(
 //                    swiftVersion: "",
 //                    plugins: <#T##[PluginLocation]#>,
         generationOptions: .options(
-            enableCaching: true
+            enableCaching: true,
+            registryEnabled: true
         )
 //                    installOptions: <#T##Tuist.InstallOptions#>)
     )


### PR DESCRIPTION
## 변경 사항

Tuist 레지스트리를 활성화하고 Swift Package Index에 등록된 패키지를 레지스트리 기반으로 마이그레이션합니다.

### 마이그레이션 결과

| 패키지 | 결과 | 비고 |
|--------|------|------|
| kakao-ios-sdk | ❌ 레지스트리 미등록 | .remote 유지 |
| MBProgressHUD | ❌ 레지스트리 미등록 | .remote 유지 |
| LSExtensions | ❌ 레지스트리 미등록 | .remote 유지 |
| Material | ❌ 레지스트리 미등록 | .remote 유지 |
| UITextView-Placeholder | ❌ 레지스트리 미등록 | .remote 유지 |
| SDWebImage | ✅ 성공 | sdwebimage.sdwebimage |
| firebase-ios-sdk | ✅ 성공 | firebase.firebase-ios-sdk |

### 변경 파일
- `Tuist.swift`: `registryEnabled: true` 추가
- `Projects/DynamicThirdParty/Project.swift`: SDWebImage, Firebase 레지스트리 ID로 교체