### PR TITLE
chore: setup Renovate for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "schedule": ["before 9am on Monday"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Tuist Project.swift - GitHub remote packages (range versions)",
+      "fileMatch": ["Projects/.+/Project\\.swift"],
+      "matchStrings": [
+        "\\.remote\\(\\s*url:\\s*\"https://github\\.com/(?<depName>[^\"./ ]+/[^\"./ ]+?)(?:\\.git)?\"\\s*,\\s*requirement:\\s*\\.upToNext(?:Major|Minor)\\(from:\\s*\"(?<currentValue>[\\d.]+)\"\\)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Tuist Project.swift - GitHub exact version packages",
+      "fileMatch": ["Projects/.+/Project\\.swift"],
+      "matchStrings": [
+        "\\.remote\\(\\s*url:\\s*\"https://github\\.com/(?<depName>[^\"./ ]+/[^\"./ ]+?)(?:\\.git)?\"\\s*,\\s*requirement:\\s*\\.exact\\(\"(?<currentValue>[\\d.]+)\"\\)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Tuist Project.swift - Tuist registry packages",
+      "fileMatch": ["Projects/.+/Project\\.swift"],
+      "matchStrings": [
+        "\\.package\\(id:\\s*\"(?<depName>[\\w][\\w.-]*)\"\\s*,\\s*from:\\s*\"(?<currentValue>[\\d.]+)\""
+      ],
+      "datasourceTemplate": "swiftpm",
+      "registryUrls": ["https://registry.tuist.io"]
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Group Firebase SDK updates together",
+      "matchPackageNames": ["firebase.firebase-ios-sdk"],
+      "groupName": "Firebase iOS SDK"
+    },
+    {
+      "description": "Disable updates for unmaintained CosmicMind/Material",
+      "matchPackageNames": ["CosmicMind/Material"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- `renovate.json` 추가: Tuist 프로젝트의 의존성 자동 업데이트 설정
- GitHub remote 패키지 (`Projects/*/Project.swift`의 `.remote(url:)`) 지원 — regex manager로 파싱
- Tuist 레지스트리 패키지 (`.package(id:)`) 지원 — `registry.tuist.io` 경유
- 매주 월요일 오전 9시 이전에 PR 생성 (업무 시작 전)
- 최대 동시 PR 5개, 시간당 2개로 제한

## Coverage

| 파일 | 패키지 | 처리 방식 |
|------|--------|---------|
| `Projects/App/Project.swift` | GADManager | regex → github-releases |
| `Projects/ThirdParty/Project.swift` | KakaoSDK, MBProgressHUD, LSExtensions, Material, UITextView-Placeholder | regex → github-releases |
| `Projects/DynamicThirdParty/Project.swift` | firebase-ios-sdk, sdwebimage | regex → swiftpm (Tuist registry) |

## Notes

- `CosmicMind/Material` 업데이트 비활성화 (장기 미유지 패키지)
- Firebase 관련 패키지는 단일 그룹 PR로 묶음

## Test plan

- [ ] Renovate GitHub App이 저장소에 설치되어 있는지 확인
- [ ] Renovate가 Dependency Dashboard 이슈를 생성하는지 확인
- [ ] PR 생성 시 regex manager가 버전을 올바르게 감지하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)