### PR TITLE
chore: add Renovate for automated dependency updates

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,20 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 22 * * 0'  # 22:00 UTC Sunday = 07:00 KST Monday
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: renovatebot/github-action@v40
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -114,3 +114,7 @@ symbol_info_budget:
 # Note: the backend is fixed at startup. If a project with a different backend
 # is activated post-init, an error will be returned.
 language_backend:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "Asia/Seoul",
+  "enabledManagers": ["mise", "custom.regex"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Registry-based .package(id:) in Project.swift (github-releases)",
+      "managerFilePatterns": ["/(^|/)Project\\.swift$/"],
+      "matchStrings": [
+        "\\.package\\(id:\\s*\"(?<depName>[\\w\\-.]+?)\"[\\s\\S]*?(?:from|exact):\\s*\"(?<currentValue>[^\"]+)\"\\)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "{{{replace '\\.' '/' depName}}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Registry-based .package(id:) in Project.swift (github-tags fallback)",
+      "managerFilePatterns": ["/(^|/)Project\\.swift$/"],
+      "matchStrings": [
+        "\\.package\\(id:\\s*\"(?<depName>[\\w\\-.]+?)\"[\\s\\S]*?(?:from|exact):\\s*\"(?<currentValue>[^\"]+)\"\\)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "packageNameTemplate": "{{{replace '\\.' '/' depName}}}"
+    },
+    {
+      "customType": "regex",
+      "description": "URL-based .remote(url:) with upToNextMajor/Minor in Project.swift (github-releases)",
+      "managerFilePatterns": ["/(^|/)Project\\.swift$/"],
+      "matchStrings": [
+        "\\.remote\\(url:\\s*\"(?:https?:\\/\\/)?github\\.com\\/(?<depName>[\\w\\-_]+\\/[\\w\\-_.]+?)(?:\\.git)?\"[\\s\\S]*?requirement:\\s*\\.(?:upToNextMajor|upToNextMinor)\\(from:\\s*\"(?<currentValue>[^\"]+)\"\\)"
+      ],
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "URL-based .remote(url:) with upToNextMajor/Minor in Project.swift (github-tags fallback)",
+      "managerFilePatterns": ["/(^|/)Project\\.swift$/"],
+      "matchStrings": [
+        "\\.remote\\(url:\\s*\"(?:https?:\\/\\/)?github\\.com\\/(?<depName>[\\w\\-_]+\\/[\\w\\-_.]+?)(?:\\.git)?\"[\\s\\S]*?requirement:\\s*\\.(?:upToNextMajor|upToNextMinor)\\(from:\\s*\"(?<currentValue>[^\"]+)\"\\)"
+      ],
+      "datasourceTemplate": "github-tags"
+    },
+    {
+      "customType": "regex",
+      "description": "URL-based .remote(url:) with .exact() in Project.swift (github-releases)",
+      "managerFilePatterns": ["/(^|/)Project\\.swift$/"],
+      "matchStrings": [
+        "\\.remote\\(url:\\s*\"(?:https?:\\/\\/)?github\\.com\\/(?<depName>[\\w\\-_]+\\/[\\w\\-_.]+?)(?:\\.git)?\"[\\s\\S]*?requirement:\\s*\\.exact\\(\"(?<currentValue>[^\"]+)\"\\)"
+      ],
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "URL-based .remote(url:) with .exact() in Project.swift (github-tags fallback)",
+      "managerFilePatterns": ["/(^|/)Project\\.swift$/"],
+      "matchStrings": [
+        "\\.remote\\(url:\\s*\"(?:https?:\\/\\/)?github\\.com\\/(?<depName>[\\w\\-_]+\\/[\\w\\-_.]+?)(?:\\.git)?\"[\\s\\S]*?requirement:\\s*\\.exact\\(\"(?<currentValue>[^\"]+)\"\\)"
+      ],
+      "datasourceTemplate": "github-tags"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["custom.regex"],
+      "groupName": "Swift dependencies",
+      "schedule": ["before 9am on Monday"]
+    },
+    {
+      "matchManagers": ["mise"],
+      "groupName": "Dev tools",
+      "schedule": ["before 9am on Monday"]
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "matchUpdateTypes": ["minor", "major"],
+      "automerge": false
+    }
+  ],
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 2
+}


### PR DESCRIPTION
## Summary

- `renovate.json` 추가: Project.swift 기반 혼합 패키지 형식(레지스트리 + URL) 지원
- `.github/workflows/renovate.yml` 추가: 매주 월요일 오전 7시(KST) 자동 실행
- `mise.toml` 지원으로 Tuist 버전도 자동 추적

### 감지된 패키지 (8개)

| 파일 | 형식 | 패키지 |
|------|------|--------|
| `DynamicThirdParty/Project.swift` | registry `.package(id:)` | SDWebImage, Firebase iOS SDK |
| `ThirdParty/Project.swift` | URL `.remote(url:)` | KakaoSDK, MBProgressHUD, LSExtensions, Material, UITextView-Placeholder |
| `App/Project.swift` | URL `.remote(url:)` | GADManager |

### automerge 정책
- patch → 자동 머지 (branch 방식)
- minor / major → PR 생성 후 수동 검토

## Test plan

- [ ] GitHub 저장소 Settings → Secrets에 `RENOVATE_TOKEN` 추가 (repo 스코프 PAT)
- [ ] Actions 탭에서 Renovate 워크플로우를 `workflow_dispatch`로 수동 실행하여 PR 생성 확인
- [ ] 생성된 Renovate PR에서 패키지가 올바르게 감지됐는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)