### PR TITLE
fix: update renovatebot/github-action to v46

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: renovatebot/github-action@v40
+      - uses: renovatebot/github-action@v46
         with:
           configurationFile: renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
## Summary

- `renovatebot/github-action@v40` → `@v46` (최신 버전)

🤖 Generated with [Claude Code](https://claude.com/claude-code)