### PR TITLE
fix: pin renovatebot/github-action to v46.1.4

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: renovatebot/github-action@v46
+      - uses: renovatebot/github-action@v46.1.4
         with:
           configurationFile: renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
## Summary

- `@v46` → `@v46.1.4` (정확한 버전 태그 사용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)