### PR TITLE
fix: add env vars to Renovate action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -18,3 +18,6 @@ jobs:
         with:
           configurationFile: renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: 'debug'
+          RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- `LOG_LEVEL: debug` 추가
- `RENOVATE_REPOSITORIES: ${{ github.repository }}` 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)