### PR TITLE
chore: disable schedule for manual dispatch testing

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,8 +1,8 @@
 name: Renovate
 
 on:
-  schedule:
-    - cron: '0 22 * * 0'  # 22:00 UTC Sunday = 07:00 KST Monday
+  # schedule:
+  #   - cron: '0 22 * * 0'  # 22:00 UTC Sunday = 07:00 KST Monday
   workflow_dispatch:
 
 permissions:

--- a/renovate.json
+++ b/renovate.json
@@ -65,12 +65,12 @@
     {
       "matchManagers": ["custom.regex"],
       "groupName": "Swift dependencies",
-      "schedule": ["before 9am on Monday"]
+      "schedule": ["at any time"]
     },
     {
       "matchManagers": ["mise"],
       "groupName": "Dev tools",
-      "schedule": ["before 9am on Monday"]
+      "schedule": ["at any time"]
     },
     {
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
## Summary

- workflow `cron` 주석 처리 → `workflow_dispatch` 전용
- `renovate.json` schedule → `"at any time"` (Renovate 스케줄 제한 해제)

테스트 완료 후 되돌릴 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)