### PR TITLE
chore: enable cron and schedule for Renovate

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,8 +1,8 @@
 name: Renovate
 
 on:
-  # schedule:
-  #   - cron: '0 22 * * 0'  # 22:00 UTC Sunday = 07:00 KST Monday
+  schedule:
+    - cron: '0 22 * * 0'  # 22:00 UTC Sunday = 07:00 KST Monday
   workflow_dispatch:
 
 permissions:

--- a/renovate.json
+++ b/renovate.json
@@ -65,12 +65,12 @@
     {
       "matchManagers": ["custom.regex"],
       "groupName": "Swift dependencies",
-      "schedule": ["at any time"]
+      "schedule": ["before 9am on Monday"]
     },
     {
       "matchManagers": ["mise"],
       "groupName": "Dev tools",
-      "schedule": ["at any time"]
+      "schedule": ["before 9am on Monday"]
     },
     {
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
## Summary

- workflow cron 복원: 매주 일요일 22:00 UTC (월요일 07:00 KST)
- renovate.json schedule 복원: `before 9am on Monday`

🤖 Generated with [Claude Code](https://claude.com/claude-code)