### PR TITLE
fix: locate Crashlytics/run dynamically for Tuist registry layout

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -80,7 +80,7 @@ let project = Project(
                      name: "Merge SKAdNetworkItems",
                      inputPaths: ["$(SRCROOT)/Resources/skNetworks.plist"],
                      basedOnDependencyAnalysis: false),
-                .post(script: "${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run",
+                .post(script: "CRASHLYTICS_RUN=$(find \"${BUILD_DIR%/Build/*}/SourcePackages\" -name run -path \"*/Crashlytics/run\" | head -1); \"$CRASHLYTICS_RUN\"",
                             name: "Upload dSYM for Crashlytics",
                             inputPaths: ["${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
                                          "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",


### PR DESCRIPTION
## Summary

- Fixes archive failure caused by hardcoded `SourcePackages/checkouts/firebase-ios-sdk/` path
- Tuist registry stores packages under `SourcePackages/registry/downloads/firebase/firebase-ios-sdk/{version}/` — the version directory changes on every update
- Uses `find` + shell variable to locate `Crashlytics/run` dynamically regardless of storage path

## Root Cause

Migration to Tuist registry (`firebase.firebase-ios-sdk`) changed where SPM unpacks the package. The old hardcoded path no longer exists at archive time.

## Change

```diff
- .post(script: "${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run",
+ .post(script: "CRASHLYTICS_RUN=$(find \"${BUILD_DIR%/Build/*}/SourcePackages\" -name run -path \"*/Crashlytics/run\" | head -1); \"$CRASHLYTICS_RUN\"",
```

## Test Plan
- [ ] Archive build succeeds without Crashlytics script error
- [ ] dSYM is uploaded to Firebase Crashlytics after archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)