### PR TITLE
fix: restore missing navigation title in RuleFilterScreen

### DIFF
--- a/Projects/App/Sources/Screens/RuleFilterScreen.swift
+++ b/Projects/App/Sources/Screens/RuleFilterScreen.swift
@@ -49,7 +49,7 @@ struct RuleFilterScreen: View {
             }
         }
         .listStyle(PlainListStyle())
-//        .navigationTitle(viewModel.title)
+        .navigationTitle(viewModel.title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {


### PR DESCRIPTION
Closes #130

Uncomments `.navigationTitle(viewModel.title)` in `RuleFilterScreen`. Users can now see which filter type (department / job title / company) they are editing in the navigation bar.

## Test Plan
- [ ] Open RuleDetailScreen and tap any filter row (department / job title / company)
- [ ] Verify navigation bar shows the correct title

🤖 Generated with [Claude Code](https://claude.com/claude-code)