### PR TITLE
chore: rename CFBundleDisplayName to Group SMS

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -59,7 +59,7 @@ let project = Project(
                     "NSUserTrackingUsageDescription": "Use location information to explore nearby attractions.",
                     "ITSAppUsesNonExemptEncryption": "NO",
                     "CFBundleShortVersionString": "${MARKETING_VERSION}",
-                    "CFBundleDisplayName": "Send Multi SMS",
+                    "CFBundleDisplayName": "Group SMS",
                     "NSAppTransportSecurity": [
                         "NSAllowsArbitraryLoads": true
                     ],


### PR DESCRIPTION
Aligns home screen label with the new App Store display name.

| | Before | After |
|---|---|---|
| Home screen | Send Multi SMS | Group SMS |
| App Store (EN) | — | Group SMS: Contact Filter |
| App Store (KO) | 보내봐 단체문자 | 보내봐 단체문자 - 연락처 필터 |

Note: App Store name changes are handled in App Store Connect — no code change needed for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)