### PR TITLE
feat: tap row to edit directly, remove edit mode

### DIFF
--- a/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
@@ -68,7 +68,6 @@ struct RecipientRuleListScreen: View {
     @State private var showingSettingsAlert = false
     @State private var showingNoContactsAlert = false
     @State private var viewModel = SARecipientListScreenModel()
-    @State private var isEditing = false
     @State private var messageComposerState: MessageComposeState = .unknown
     @State private var skipPhoneNumberWarning = false
 	@State private var isBatchSending = false
@@ -125,21 +124,17 @@ struct RecipientRuleListScreen: View {
                                 }
                                 .frame(height: 100)
                                 .onTapGesture {
-                                    guard isEditing else { return }
-
                                     presentFullAdThen { @MainActor in
                                         state = .editingRule(rule)
                                     }
                                 }
-                                .if(isEditing) { view in
-                                    view.swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                        Button(role: .destructive) {
-                                            // Added print statement before deletion
-                                            print("Deleting rule - id: \(rule.id), title: \(rule.title ?? "")")
-                                            deleteRule(rule)
-                                        } label: {
-                                            Label("Delete".localized(), systemImage: "trash")
-                                        }
+                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                    Button(role: .destructive) {
+                                        // Added print statement before deletion
+                                        print("Deleting rule - id: \(rule.id), title: \(rule.title ?? "")")
+                                        deleteRule(rule)
+                                    } label: {
+                                        Label("Delete".localized(), systemImage: "trash")
                                     }
                                 }
                             }
@@ -168,14 +163,6 @@ struct RecipientRuleListScreen: View {
         .navigationTitle("rules.title".localized())
         .navigationBarTitleDisplayMode(.large)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                if !rules.isEmpty {
-                    Button(isEditing ? "Cancel".localized() : "Edit".localized()) {
-                        isEditing.toggle()
-                    }.tint(Color.accent)
-                }
-            }
-
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {
                     if isAddFirstFilterTipVisible {


### PR DESCRIPTION
Closes #129
Closes #148

## Changes

- Row tap always navigates to `RuleDetailScreen` — no edit mode required
- Removed `@State isEditing`, Edit toolbar button, and `.if(isEditing)` wrapper
- Swipe-to-delete always available on every row

## User Flow

```mermaid
flowchart TD
    A([User taps filter row]) --> B[RuleDetailScreen opens]
    A2([User swipes left on row]) --> C[Delete button appears]
    C --> D[Row deleted]
```

## Test Plan
- [ ] Tap any filter row → RuleDetailScreen opens immediately (no edit button needed)
- [ ] Swipe left on any row → delete button appears
- [ ] Edit toolbar button is gone
- [ ] All existing ad flow and navigation intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)