### PR TITLE
feat: warn on unsaved changes before dismissing RuleDetailScreen

### DIFF
--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -57,6 +57,8 @@
 // RuleDetailScreen
 "Rule Title" = "Filter Title";
 "Enter rule title" = "Enter filter title";
+"unsaved.changes.title" = "Save Changes?";
+"unsaved.changes.discard" = "Don't Save";
 
 // Common actions
 "Edit" = "Edit";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -49,6 +49,8 @@
 // RuleDetailScreen
 "Rule Title" = "필터 이름";
 "Enter rule title" = "필터 이름을 입력하세요";
+"unsaved.changes.title" = "변경사항을 저장하시겠습니까?";
+"unsaved.changes.discard" = "저장 안 함";
 
 // Common actions
 "Edit" = "편집";

--- a/Projects/App/Sources/Screens/RuleDetailScreen.swift
+++ b/Projects/App/Sources/Screens/RuleDetailScreen.swift
@@ -16,6 +16,7 @@ struct RuleDetailScreen: View {
 	
 	@State private var viewModel: RuleDetailScreenModel
 	@State private var selectedFilter: RecipientsFilter?
+	@State private var showDiscardConfirmation: Bool = false
 	
 	init(rule: RecipientsRule?) {
 		_viewModel = State(initialValue: RuleDetailScreenModel(rule: rule))
@@ -77,13 +78,14 @@ struct RuleDetailScreen: View {
 		.toolbar {
 			ToolbarItem(placement: .navigationBarLeading) {
                 Button(action: {
-                    print("커스텀 뒤로 가기 버튼이 눌렸습니다.")
-                    
-                    if let undoManager {
-                        viewModel.rollback(withUndoManager: undoManager)
+                    if viewModel.hasChanges {
+                        showDiscardConfirmation = true;
+                    } else {
+                        if let undoManager {
+                            viewModel.rollback(withUndoManager: undoManager);
+                        }
+                        dismiss();
                     }
-                    
-                    dismiss()
                 }) {
                     HStack(alignment: .center, spacing: 4) {
                         Image(systemName: "chevron.left")
@@ -107,9 +109,26 @@ struct RuleDetailScreen: View {
 //			case "org": title = "조직 필터"
 //			default: title = "필터"
 //			}
-			
+
             RuleFilterScreen(filter: filter)
         }
+		.confirmationDialog(
+			"unsaved.changes.title".localized(),
+			isPresented: $showDiscardConfirmation,
+			titleVisibility: .visible
+		) {
+			Button("Save".localized()) {
+				viewModel.save(using: modelContext);
+				dismiss();
+			}
+			Button("unsaved.changes.discard".localized(), role: .destructive) {
+				if let undoManager {
+					viewModel.rollback(withUndoManager: undoManager);
+				}
+				dismiss();
+			}
+			Button("Cancel".localized(), role: .cancel) {}
+		}
 	}
 }
 

--- a/Projects/App/Sources/ViewModels/RuleDetailScreenModel.swift
+++ b/Projects/App/Sources/ViewModels/RuleDetailScreenModel.swift
@@ -12,11 +12,15 @@ import SwiftData
 class RuleDetailScreenModel {
 	var rule: RecipientsRule?
 	var title: String = ""
-    var isSaved: Bool = false
-	
+	var isSaved: Bool = false
+
+	var hasChanges: Bool {
+		title != (rule?.title ?? "");
+	}
+
 	init(rule: RecipientsRule?) {
-		self.rule = rule
-        self.title = rule?.title ?? ""
+		self.rule = rule;
+		self.title = rule?.title ?? "";
 	}
 	
     func save(using context: ModelContext) {


### PR DESCRIPTION
Closes #131

## Changes

- `RuleDetailScreenModel.hasChanges` — dirty-state check comparing current title vs persisted
- Back button triggers `.confirmationDialog` when changes are pending
- New localization keys: `unsaved.changes.title`, `unsaved.changes.discard`

## User Flow

```mermaid
flowchart TD
    A([User edits filter]) --> B{Taps back button}
    B --> C{hasChanges?}
    C -- No --> D[rollback + dismiss]
    C -- Yes --> E[confirmationDialog appears]
    E --> F[저장] --> G[save + dismiss]
    E --> H[저장 안 함] --> D
    E --> I[취소] --> A
```

## Test Plan
- [ ] Edit filter title → tap back → confirmation dialog appears
- [ ] Tap 저장 → changes saved, screen dismissed
- [ ] Tap 저장 안 함 → changes discarded, screen dismissed
- [ ] Tap 취소 → stays on screen
- [ ] No changes made → tap back → dismisses without dialog

## Result
<img width="366" height="272" alt="스크린샷 2026-03-12 오후 2 29 30" src="https://github.com/user-attachments/assets/e4f2734e-8cb2-4380-b03c-dc412e9dd5b8" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)