### PR TITLE
feat: show filter condition summary in RecipientListRowView

### DIFF
--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -49,6 +49,7 @@
 "success.popup.dismiss" = "Rate the App";
 
 // RuleListScreen
+"rule.row.allContacts" = "All Contacts";
 "rules.empty" = "There are no contact filters";
 "rules.empty.description" = "Try adding a new contact filter";
 "rules.title" = "Contact Filter List";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -41,6 +41,7 @@
 "New Rule" = "새 필터";
 
 // RecipientRuleListScreen
+"rule.row.allContacts" = "모든 연락처";
 "rules.empty" = "연락처 필터가 없습니다";
 "rules.empty.description" = "새로운 연락처 필터를 추가해보세요";
 "rules.title" = "연락처 필터 목록";

--- a/Projects/App/Sources/Screens/RecipientList/RecipientListRowView.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientListRowView.swift
@@ -9,57 +9,87 @@ import SwiftUI
 import SwiftData
 
 struct RecipientRuleRowView: View {
-    let rule: RecipientsRule
-    let onToggle: (Bool) -> Void
-    
-    var isTitleEmpty: Bool {
-        return rule.title?.isEmpty ?? true
-    }
-    
-    var body: some View {
-        ZStack {
-            // 배경색
-            Color.background
-            
-            // 컨텐츠
-            HStack {
-                VStack(alignment: .leading, spacing: 4) {
-                    if let title = rule.title, !title.isEmpty {
-                        Text(title)
-                    } else {
-                        Text("수신자 목록 생성 규칙")
-                            .font(.headline)
-                    }
-                }
-                .font(.headline)
-                .foregroundStyle(Color.title)
+	let rule: RecipientsRule
+	let onToggle: (Bool) -> Void
 
-                
-                Spacer()
-                
-                Toggle("", isOn: Binding(
-                    get: { rule.enabled },
-                    set: { onToggle($0) }
-                )).padding(.trailing, 16)
-            }
-            .padding(.leading, 32)
-            .padding(.trailing, 16)
-        }
-    }
+	var isTitleEmpty: Bool {
+		return rule.title?.isEmpty ?? true;
+	}
+
+	private func filterText(for rawTarget: String) -> String? {
+		guard let filters = rule.filters else { return nil; }
+		let filter = filters.first { $0.target == rawTarget };
+		if filter == nil || filter?.all == true { return nil; }
+		guard let includes = filter?.includes else { return nil; }
+		let keywords = includes.components(separatedBy: ",").filter { !$0.isEmpty };
+		guard !keywords.isEmpty else { return nil; }
+		if keywords.count == 1 { return keywords[0]; }
+		return "\(keywords[0])".localized() + " and \(keywords.count - 1) others".localized();
+	}
+
+	private var filterSummary: String {
+		var parts: [String] = [];
+		let targets: [(rawValue: String, labelKey: String)] = [
+			("job", "Job"),
+			("dept", "Department"),
+			("org", "Organization"),
+		];
+		for (rawValue, labelKey) in targets {
+			if let value = filterText(for: rawValue) {
+				parts.append("\(labelKey.localized()): \(value)");
+			}
+		}
+		if parts.isEmpty {
+			return "rule.row.allContacts".localized();
+		}
+		return parts.joined(separator: "  |  ");
+	}
+
+	var body: some View {
+		ZStack {
+			Color.background
+
+			HStack {
+				VStack(alignment: .leading, spacing: 4) {
+					if let title = rule.title, !title.isEmpty {
+						Text(title)
+							.font(.headline)
+							.foregroundStyle(Color.title)
+					} else {
+						Text("수신자 목록 생성 규칙")
+							.font(.headline)
+							.foregroundStyle(Color.title)
+					}
+
+					Text(filterSummary)
+						.font(.caption)
+						.foregroundStyle(.secondary)
+				}
+
+				Spacer()
+
+				Toggle("", isOn: Binding(
+					get: { rule.enabled },
+					set: { onToggle($0) }
+				)).padding(.trailing, 16)
+			}
+			.padding(.leading, 32)
+			.padding(.trailing, 16)
+			.padding(.vertical, 12)
+		}
+	}
 }
 
 struct RecipientRuleRowView_Previews: PreviewProvider {
-    static var previews: some View {
-        let config = ModelConfiguration(isStoredInMemoryOnly: true)
-        let container = try! ModelContainer(for: RecipientsRule.self, configurations: config)
-        
-        let rule = RecipientsRule(title: "테스트 규칙", enabled: true)
-        container.mainContext.insert(rule)
-        
-        return RecipientRuleRowView(rule: rule) { isOn in
-            // Preview용 클로저
-        }
-        .previewLayout(.fixed(width: 350, height: 60))
-        .modelContainer(container)
-    }
+	static var previews: some View {
+		let config = ModelConfiguration(isStoredInMemoryOnly: true)
+		let container = try! ModelContainer(for: RecipientsRule.self, configurations: config)
+
+		let rule = RecipientsRule(title: "회사 동료들", enabled: true)
+		container.mainContext.insert(rule)
+
+		return RecipientRuleRowView(rule: rule) { isOn in }
+			.previewLayout(.sizeThatFits)
+			.modelContainer(container)
+	}
 }

--- a/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
@@ -122,7 +122,6 @@ struct RecipientRuleListScreen: View {
                                 RecipientRuleRowView(rule: rule) { isEnabled in
                                     toggleRule(rule, isEnabled: isEnabled)
                                 }
-                                .frame(height: 100)
                                 .onTapGesture {
                                     presentFullAdThen { @MainActor in
                                         state = .editingRule(rule)


### PR DESCRIPTION
Closes #132

## Changes

- `filterSummary` computed property in `RecipientListRowView`
- Active conditions shown as subtitle (직책 / 부서 / 회사), separated by `  |  `
- "모두" conditions omitted; falls back to "모든 연락처" when all default
- Removed fixed `frame(height: 100)` — Dynamic Type aware

## Before / After

```
Before:
┌──────────────────────────────────────┐
│                                      │
│  회사 동료들                    [토글] │
│                                      │
└──────────────────────────────────────┘

After:
┌──────────────────────────────────────┐
│  회사 동료들                    [토글] │
│  직책: 팀장  |  부서: 개발팀          │
└──────────────────────────────────────┘
```

## Test Plan
- [ ] Filter with conditions → subtitle shows active conditions separated by |
- [ ] Filter with all conditions as 모두 → subtitle shows 모든 연락처
- [ ] Row height adjusts naturally with Dynamic Type
- [ ] Fixed height 100pt is gone

## Result
<img width="373" height="284" alt="스크린샷 2026-03-12 오후 2 38 00" src="https://github.com/user-attachments/assets/f1db3d46-9e34-4b52-b241-4e89b299bd63" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)