### PR TITLE
feat: show batch progress in loading overlay during group send

### DIFF
--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -42,6 +42,7 @@
 
 // Sending warnings
 "send.warning.batchSending" = "You are about to send message to %d recipients.\nRecipients will be separated into groups of %d for sending.";
+"send.batch.progress" = "(Batch %d/%d — %d recipients)";
 
 // Success popup (review request after 5 sends)
 "success.popup.title" = "Congratulations!";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -63,6 +63,7 @@
 
 // Sending warnings
 "send.warning.batchSending" = "메시지를 %d명의 수신자에게 전송하려고 합니다.\n수신자를 %d명씩 나누어 전송합니다.";
+"send.batch.progress" = "(배치 %d/%d — 수신자 %d명)";
 
 
 // SplashScreen

--- a/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
@@ -72,7 +72,8 @@ struct RecipientRuleListScreen: View {
     @State private var skipPhoneNumberWarning = false
 	@State private var isBatchSending = false
 	@State private var allPhoneNumbers: [String] = []
-	    @State private var currentBatchIndex: Int = 0
+	@State private var currentBatchIndex: Int = 0
+	@State private var batchProgressText: String = ""
 	    private let batchSize: Int = 20
 	    private let addFirstFilterTip = AddFirstFilterTip()
 	    @State private var isAddFirstFilterTipVisible = false
@@ -231,6 +232,13 @@ struct RecipientRuleListScreen: View {
 							.foregroundColor(.white)
 							.multilineTextAlignment(.center)
 							.font(.system(size: 14))
+
+						if !batchProgressText.isEmpty {
+							Text(batchProgressText)
+								.foregroundColor(.white.opacity(0.8))
+								.multilineTextAlignment(.center)
+								.font(.system(size: 12))
+						}
 					}
 				}
 			}
@@ -428,18 +436,17 @@ struct RecipientRuleListScreen: View {
 		guard isBatchSending else { return false }
 		let start = currentBatchIndex * batchSize
 		guard start < allPhoneNumbers.count else {
-			// 모든 배치 완료
-			print("Batch sending completed. total: \(allPhoneNumbers.count)")
 			isBatchSending = false
 			allPhoneNumbers = []
 			currentBatchIndex = 0
+			batchProgressText = ""
 			return true
 		}
 		let end = min(start + batchSize, allPhoneNumbers.count)
 		let batch = Array(allPhoneNumbers[start..<end])
 		let totalBatches = Int(ceil(Double(allPhoneNumbers.count) / Double(batchSize)))
 		let currentNumber = currentBatchIndex + 1
-		print("Presenting batch \(currentNumber)/\(totalBatches) [range: \(start)..<\(end), count: \(batch.count)]")
+		batchProgressText = String(format: "send.batch.progress".localized(), currentNumber, totalBatches, batch.count)
 		viewModel.phoneNumbers = batch
 		isMessageComposerLoading = true
 		showingMessageComposer = true


### PR DESCRIPTION
Closes #133

## Changes

- `batchProgressText` state updated before each batch is presented
- Loading overlay now shows `(배치 N/T — 수신자 M명)` beneath the status label
- Only visible during batch sends (>20 recipients), hidden for single batch
- New localization key `send.batch.progress`

## Before / After

```
Before:                    After:
┌─────────────────┐        ┌─────────────────────────────┐
│  작성화면 준비 중  │        │      작성화면 준비 중          │
└─────────────────┘        │  (배치 2/5 — 수신자 40명)     │
                           └─────────────────────────────┘
```

## Test Plan
- [ ] Send to >20 recipients → overlay shows batch progress (배치 1/N)
- [ ] Each batch advances the counter
- [ ] Send to ≤20 recipients → no batch text shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)