### PR TITLE
feat: add CTA button to EmptyStateView

### DIFF
--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -53,6 +53,7 @@
 "rule.row.allContacts" = "All Contacts";
 "rules.empty" = "There are no contact filters";
 "rules.empty.description" = "Try adding a new contact filter";
+"rules.empty.cta" = "+ Add First Filter";
 "rules.title" = "Contact Filter List";
 "rules.add" = "Add New Filter";
 

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -44,6 +44,7 @@
 "rule.row.allContacts" = "모든 연락처";
 "rules.empty" = "연락처 필터가 없습니다";
 "rules.empty.description" = "새로운 연락처 필터를 추가해보세요";
+"rules.empty.cta" = "+ 첫 번째 필터 추가";
 "rules.title" = "연락처 필터 목록";
 "rules.add" = "새 필터 추가";
 

--- a/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
@@ -109,7 +109,11 @@ struct RecipientRuleListScreen: View {
                 .edgesIgnoringSafeArea(.all)
 
             if rules.isEmpty {
-                EmptyStateView()
+                EmptyStateView {
+                    presentFullAdThen { @MainActor in
+                        state = .creatingRule
+                    }
+                }
             } else {
                 List {
                     // 규칙 섹션 + 네이티브 광고 섞어 보여주기

--- a/Projects/App/Sources/Views/RecipientComponents.swift
+++ b/Projects/App/Sources/Views/RecipientComponents.swift
@@ -12,19 +12,27 @@ import Combine
 
 // MARK: - Supporting Views
 struct EmptyStateView: View {
+	let onAddTapped: () -> Void
+
 	var body: some View {
 		VStack(spacing: 20) {
 			Image(systemName: "person.3.fill")
 				.font(.system(size: 60))
-				.foregroundColor(.gray)
+				.foregroundStyle(.secondary)
 
-            Text("rules.empty".localized())
+			Text("rules.empty".localized())
 				.font(.title2)
-				.foregroundColor(.gray)
+				.foregroundStyle(.secondary)
 
-            Text("rules.empty.description".localized())
+			Text("rules.empty.description".localized())
 				.font(.body)
-				.foregroundColor(.gray)
+				.foregroundStyle(.secondary)
+
+			Button(action: onAddTapped) {
+				Text("rules.empty.cta".localized())
+			}
+			.buttonStyle(.borderedProminent)
+			.tint(.accent)
 		}
 	}
 }


### PR DESCRIPTION
Closes #134

## Changes

- `EmptyStateView` gains `onAddTapped` closure parameter
- `.borderedProminent` button added at bottom of empty state
- Triggers same flow as toolbar `+` button including full-ad gate
- New localization key `rules.empty.cta`

## Test Plan
- [ ] Empty state shows "+ 첫 번째 필터 추가" button
- [ ] Tapping button opens new filter creation flow
- [ ] TipKit popover on toolbar + is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)