### PR TITLE
feat: rewarded ad — ad-free for 1 hour

### DIFF
--- a/Projects/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Projects/App/Resources/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -24,8 +24,8 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "0.000",
-          "green" : "1.000",
-          "red" : "0.000"
+          "green" : "0.800",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/Projects/App/Resources/Assets.xcassets/Colors/accent.colorset/Contents.json
+++ b/Projects/App/Resources/Assets.xcassets/Colors/accent.colorset/Contents.json
@@ -24,8 +24,8 @@
         "components" : {
           "alpha" : "1.000",
           "blue" : "0.000",
-          "green" : "1.000",
-          "red" : "0.000"
+          "green" : "0.800",
+          "red" : "1.000"
         }
       },
       "idiom" : "universal"

--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -99,3 +99,5 @@
 "watch.ad.action" = "Watch Ad";
 "watch.ad.message" = "Watch a short ad to enjoy 1 hour ad-free.";
 "watch.ad.toast" = "Ad-free for 1 hour";
+"watch.ad.accessibility.label" = "Watch ad for 1 hour ad-free";
+"watch.ad.accessibility.hint" = "Double tap to watch a short ad and remove ads for one hour";

--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -94,3 +94,8 @@
 "message_add_rule_tip" = "Tap here to create your first contact filter.";
 
 
+
+"watch.ad.title" = "Remove ads for 1 hour?";
+"watch.ad.action" = "Watch Ad";
+"watch.ad.message" = "Watch a short ad to enjoy 1 hour ad-free.";
+"watch.ad.toast" = "Ad-free for 1 hour";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -89,3 +89,8 @@
 "title_add_rule_tip" = "첫 번째 필터 추가";
 "message_add_rule_tip" = "연락처 필터를 만들려면 여기를 누르세요.";
 
+
+"watch.ad.title" = "1시간 광고 없애기";
+"watch.ad.action" = "광고 보기";
+"watch.ad.message" = "짧은 광고를 시청하면 1시간 동안 광고 없이 이용할 수 있어요.";
+"watch.ad.toast" = "1시간 광고 없음";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -94,3 +94,5 @@
 "watch.ad.action" = "광고 보기";
 "watch.ad.message" = "짧은 광고를 시청하면 1시간 동안 광고 없이 이용할 수 있어요.";
 "watch.ad.toast" = "1시간 광고 없음";
+"watch.ad.accessibility.label" = "광고 보고 1시간 광고 없애기";
+"watch.ad.accessibility.hint" = "두 번 탭하면 짧은 광고를 보고 1시간 동안 광고 없이 이용할 수 있어요";

--- a/Projects/App/Sources/App.swift
+++ b/Projects/App/Sources/App.swift
@@ -18,7 +18,6 @@ struct SendadvApp: App {
     // SceneDelegate의 기능을 SwiftUI ObservableObject로 마이그레이션
     @StateObject private var adManager = SwiftUIAdManager()
     @StateObject private var reviewManager = ReviewManager()
-    @StateObject private var rewardAd = SwiftUIRewardAdManager()
     
     var body: some Scene {
         WindowGroup {
@@ -63,15 +62,14 @@ struct SendadvApp: App {
             return
         }
         
-        MobileAds.shared.start { [weak adManager, weak rewardAd] status in
-            guard let adManager = adManager,
-                  let rewardAd = rewardAd else { return }
-            
-            rewardAd.setup(unitId: InterstitialAd.loadUnitId(name: "RewardAd") ?? "", interval: 60.0 * 60.0 * 24)
+        MobileAds.shared.start { [weak adManager] status in
+            guard let adManager = adManager else { return }
+
             adManager.setup()
             
             MobileAds.shared.requestConfiguration.testDeviceIdentifiers = ["8a00796a760e384800262e0b7c3d08fe"]
 
+            adManager.prepare(rewardUnit: .rewarded)
             adManager.prepare(interstitialUnit: .full, interval: 60.0)
             #if DEBUG
             adManager.prepare(openingUnit: .launch, interval: 60.0)
@@ -125,13 +123,15 @@ class SwiftUIAdManager: NSObject, ObservableObject {
         case full = "FullAd"
         case launch = "Launch"
         case native = "Native"
+        case rewarded = "RewardAd"
     }
-    
+
 #if DEBUG
     var testUnits: [GADUnitName] = [
         .full,
         .launch,
         .native,
+        .rewarded,
     ]
 #else
     var testUnits: [GADUnitName] = []
@@ -164,6 +164,10 @@ class SwiftUIAdManager: NSObject, ObservableObject {
     func prepare(openingUnit unit: GADUnitName, interval: TimeInterval) {
         gadManager?.prepare(openingUnit: unit, isTesting: self.isTesting(unit: unit), interval: interval)
     }
+
+    func prepare(rewardUnit unit: GADUnitName) {
+        gadManager?.prepare(rewardUnit: unit, isTesting: self.isTesting(unit: unit))
+    }
     
     /// Shows an ad for the specified unit.
     /// 
@@ -172,19 +176,29 @@ class SwiftUIAdManager: NSObject, ObservableObject {
     @MainActor
     @discardableResult
     func show(unit: GADUnitName) async -> Bool {
-        await withCheckedContinuation { continuation in
+        guard !LSDefaults.isAdFree else { return false }
+        return await withCheckedContinuation { continuation in
             guard let gadManager else {
                 continuation.resume(returning: false)
                 return
             }
-            
-            gadManager.show(unit: unit, isTesting: self.isTesting(unit: unit) ){ unit, _,result  in
+
+            gadManager.show(unit: unit, isTesting: self.isTesting(unit: unit)) { unit, _, result in
                 continuation.resume(returning: result)
             }
         }
     }
-    
+
+    @MainActor
+    func showRewarded(completion: @escaping (Bool) -> Void) {
+        guard let gadManager else { completion(false); return }
+        gadManager.show(unit: .rewarded, needToWait: true, isTesting: isTesting(unit: .rewarded)) { _, _, rewarded in
+            completion(rewarded)
+        }
+    }
+
     func createAdLoader(forUnit unit: GADUnitName, options: [NativeAdViewAdOptions] = []) -> AdLoader? {
+        guard !LSDefaults.isAdFree else { return nil }
         return gadManager?.createNativeLoader(forAd: unit, isTesting: self.isTesting(unit: unit))
     }
     

--- a/Projects/App/Sources/Datas/LSDefaults.swift
+++ b/Projects/App/Sources/Datas/LSDefaults.swift
@@ -146,6 +146,17 @@ extension LSDefaults{
     static func updateReviewRequestDate() {
         ReviewRequestedDate = Date()
     }
-    
+
+    static var isAdFree: Bool {
+        #if DEBUG
+        return Date().timeIntervalSince(LastRewardShown) < 5 * 60
+        #else
+        return Date().timeIntervalSince(LastRewardShown) < 60 * 60
+        #endif
+    }
+
+    static func activateAdFree() {
+        LastRewardShown = Date()
+    }
 }
 

--- a/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
@@ -74,6 +74,8 @@ struct RecipientRuleListScreen: View {
 	@State private var allPhoneNumbers: [String] = []
 	@State private var currentBatchIndex: Int = 0
 	@State private var batchProgressText: String = ""
+	@State private var isAdFree: Bool = LSDefaults.isAdFree
+	@State private var showAdFreeToast = false
 	    private let batchSize: Int = 20
 	    private let addFirstFilterTip = AddFirstFilterTip()
 	    @State private var isAddFirstFilterTipVisible = false
@@ -110,7 +112,7 @@ struct RecipientRuleListScreen: View {
 
             List {
                 Section {
-                    if !rules.isEmpty {
+                    if !rules.isEmpty && !isAdFree {
                         NativeAdRowView()
                     }
                     ForEach(rules) { rule in
@@ -146,6 +148,13 @@ struct RecipientRuleListScreen: View {
                     Spacer()
                     HStack {
                         Spacer()
+                        WatchAdButton(isAdFree: $isAdFree) {
+                            showAdFreeToast = true
+                            Task {
+                                try? await Task.sleep(for: .seconds(2))
+                                showAdFreeToast = false
+                            }
+                        }
                         SendButton {
                             onSendMessage()
                         }
@@ -153,6 +162,21 @@ struct RecipientRuleListScreen: View {
                     .padding(.trailing, 20)
                     .padding(.bottom, 20)
                 }
+            }
+
+            // 광고 없음 토스트
+            if showAdFreeToast {
+                VStack {
+                    Spacer()
+                    Text("watch.ad.toast".localized())
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .background(Color.accent.opacity(0.9), in: Capsule())
+                        .padding(.bottom, 90)
+                }
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
             }
         }
         .navigationTitle("rules.title".localized())
@@ -200,6 +224,11 @@ struct RecipientRuleListScreen: View {
                 AddFirstFilterTip.hasFilters = !rules.isEmpty
             }
         }
+        .onReceive(Timer.publish(every: 30, on: .main, in: .common).autoconnect()) { _ in
+            isAdFree = LSDefaults.isAdFree
+        }
+        .animation(.easeInOut(duration: 0.25), value: isAdFree)
+        .animation(.easeInOut(duration: 0.3), value: showAdFreeToast)
         .sheet(isPresented: $showingMessageComposer) {
 			ZStack {
 				MessageComposerView(

--- a/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
@@ -146,7 +146,7 @@ struct RecipientRuleListScreen: View {
             if !rules.isEmpty {
                 VStack {
                     Spacer()
-                    HStack {
+                    HStack(alignment: .bottom, spacing: 12) {
                         Spacer()
                         WatchAdButton(isAdFree: $isAdFree) {
                             showAdFreeToast = true

--- a/Projects/App/Sources/Views/WatchAdButton.swift
+++ b/Projects/App/Sources/Views/WatchAdButton.swift
@@ -1,0 +1,55 @@
+//
+//  WatchAdButton.swift
+//  sendadv
+//
+//  Created by 영준 이 on 3/23/26.
+//  Copyright © 2026 leesam. All rights reserved.
+//
+
+import SwiftUI
+
+struct WatchAdButton: View {
+	@EnvironmentObject private var adManager: SwiftUIAdManager
+	@Binding var isAdFree: Bool
+	var onAdFreeActivated: (() -> Void)?
+
+	@State private var showConfirmation = false
+
+	var body: some View {
+		if !isAdFree {
+			Button(action: {
+				showConfirmation = true
+			}) {
+				Image(systemName: "gift")
+					.font(.system(size: 20, weight: .medium))
+					.frame(width: 44, height: 44)
+					.foregroundColor(.accent)
+			}
+			.buttonStyle(.plain)
+			.transition(.opacity.combined(with: .scale(scale: 0.8)))
+			.confirmationDialog(
+				"watch.ad.title".localized(),
+				isPresented: $showConfirmation,
+				titleVisibility: .visible
+			) {
+				Button("watch.ad.action".localized()) {
+					Task { @MainActor in
+						adManager.showRewarded { rewarded in
+							if rewarded {
+								LSDefaults.activateAdFree()
+								withAnimation(.easeInOut(duration: 0.25)) {
+									isAdFree = true
+								}
+								onAdFreeActivated?()
+							}
+						}
+					}
+				}
+				Button(role: .cancel) {
+				} label: { Text("Cancel".localized()) }
+			} message: {
+				Text("watch.ad.message".localized())
+			}
+		}
+	}
+}

--- a/Projects/App/Sources/Views/WatchAdButton.swift
+++ b/Projects/App/Sources/Views/WatchAdButton.swift
@@ -26,7 +26,7 @@ struct WatchAdButton: View {
 						.shadow(color: .black.opacity(0.25), radius: 6, x: 0, y: 3)
 					Image(systemName: "gift.fill")
 						.font(.system(size: 18, weight: .medium))
-						.foregroundStyle(Color.accent)
+						.foregroundStyle(Color.yellow)
 				}
 				.frame(width: 44, height: 44)
 			}

--- a/Projects/App/Sources/Views/WatchAdButton.swift
+++ b/Projects/App/Sources/Views/WatchAdButton.swift
@@ -20,13 +20,20 @@ struct WatchAdButton: View {
 			Button(action: {
 				showConfirmation = true
 			}) {
-				Image(systemName: "gift")
-					.font(.system(size: 20, weight: .medium))
-					.frame(width: 44, height: 44)
-					.foregroundColor(.accent)
+				ZStack {
+					Circle()
+						.fill(Color(.secondarySystemGroupedBackground))
+						.shadow(color: .black.opacity(0.15), radius: 6, x: 0, y: 3)
+					Image(systemName: "gift.fill")
+						.font(.system(size: 18, weight: .medium))
+						.foregroundStyle(Color.accentColor)
+				}
+				.frame(width: 44, height: 44)
 			}
 			.buttonStyle(.plain)
-			.transition(.opacity.combined(with: .scale(scale: 0.8)))
+			.accessibilityLabel("watch.ad.accessibility.label".localized())
+			.accessibilityHint("watch.ad.accessibility.hint".localized())
+			.transition(.opacity.combined(with: .scale(scale: 0.85)))
 			.confirmationDialog(
 				"watch.ad.title".localized(),
 				isPresented: $showConfirmation,

--- a/Projects/App/Sources/Views/WatchAdButton.swift
+++ b/Projects/App/Sources/Views/WatchAdButton.swift
@@ -26,7 +26,7 @@ struct WatchAdButton: View {
 						.shadow(color: .black.opacity(0.25), radius: 6, x: 0, y: 3)
 					Image(systemName: "gift.fill")
 						.font(.system(size: 18, weight: .medium))
-						.foregroundStyle(Color.yellow)
+						.foregroundStyle(Color.accent)
 				}
 				.frame(width: 44, height: 44)
 			}

--- a/Projects/App/Sources/Views/WatchAdButton.swift
+++ b/Projects/App/Sources/Views/WatchAdButton.swift
@@ -22,11 +22,11 @@ struct WatchAdButton: View {
 			}) {
 				ZStack {
 					Circle()
-						.fill(Color(.secondarySystemGroupedBackground))
-						.shadow(color: .black.opacity(0.15), radius: 6, x: 0, y: 3)
+						.fill(Color(.tertiarySystemBackground))
+						.shadow(color: .black.opacity(0.25), radius: 6, x: 0, y: 3)
 					Image(systemName: "gift.fill")
 						.font(.system(size: 18, weight: .medium))
-						.foregroundStyle(Color.accentColor)
+						.foregroundStyle(Color.accent)
 				}
 				.frame(width: 44, height: 44)
 			}


### PR DESCRIPTION
## Summary

- Rewarded ad 시청 시 1시간 광고 없음 (DEBUG: 5분)
- 전송 버튼 옆 gift 버튼 → confirmationDialog → 광고 재생 → NativeAd 숨김 + toast
- `SwiftUIRewardAdManager` 제거, `SwiftUIAdManager`로 통합

## User Flow

\`\`\`mermaid
flowchart TD
    A([사용자가 gift 버튼 탭]) --> B[confirmationDialog 표시]
    B --> C{광고 보기 선택?}
    C -- 취소 --> D[변경 없음]
    C -- 광고 보기 --> E[리워드 광고 재생]
    E --> F{완료?}
    F -- 스킵/종료 --> D
    F -- 완료 --> G[LSDefaults.activateAdFree]
    G --> H[gift 버튼 숨김\nNativeAd 숨김\nwithAnimation]
    H --> I[Toast: 1시간 광고 없음\n2초 후 자동 닫힘]
    I --> J([광고 없이 이용])
    J --> K[30초 타이머 isAdFree 체크]
    K --> L{1시간 경과?}
    L -- No --> J
    L -- Yes --> M[NativeAd 재표시\ngift 버튼 재표시\n조용히]
\`\`\`

## Test plan
- [ ] gift 버튼 탭 → confirmationDialog 표시
- [ ] 광고 완료 → gift 버튼 + NativeAd 사라짐 + toast 표시
- [ ] toast 2초 후 자동 닫힘
- [ ] 인터스티셜 광고 isAdFree 중 억제됨
- [ ] 30분 후(DEBUG: 5분 후) NativeAd + gift 버튼 조용히 재표시

## Result
<img width="151" height="113" alt="스크린샷 2026-03-24 오후 9 09 39" src="https://github.com/user-attachments/assets/f3362332-889c-4924-9533-2119e3aaf4aa" />
<img width="144" height="105" alt="스크린샷 2026-03-24 오후 9 10 02" src="https://github.com/user-attachments/assets/2c759011-b915-48fc-87de-4283fc045092" />

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)