### PR TITLE
ci: use Xcode 26.5

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Select Xcode
       run: |
-        sudo xcode-select -s /Applications/Xcode_26.1.1.app
+        sudo xcode-select -s /Applications/Xcode_26.5.app
 
     - name: Install Mise
       uses: jdx/mise-action@v2

--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Select Xcode
         run: |
-          sudo xcode-select -s /Applications/Xcode_26.1.1.app
+          sudo xcode-select -s /Applications/Xcode_26.5.app
 
       - name: Install Mise
         uses: jdx/mise-action@v2


### PR DESCRIPTION
## Summary
- Update Build & Test CI Xcode selection to Xcode 26.5
- Update Deploy CI Xcode selection to Xcode 26.5

## Verification
- Confirmed workflow references now point to /Applications/Xcode_26.5.app
- No app code changed

## Impact
- CI-only change; no user-flow changes