### PR TITLE
fix: pin Firebase to 12.13.0

### DIFF
--- a/Projects/DynamicThirdParty/Project.swift
+++ b/Projects/DynamicThirdParty/Project.swift
@@ -4,7 +4,7 @@ import ProjectDescriptionHelpers
 let project = Project(
     name: "DynamicThirdParty",
     packages: [        .package(id: "sdwebimage.sdwebimage", from: "5.21.7"),
-                       .package(id: "firebase.firebase-ios-sdk", from: "12.11.0"),
+                       .package(id: "firebase.firebase-ios-sdk", exact: "12.13.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
- Pin Firebase to exact 12.13.0 to avoid Firebase 12.15.0 / GoogleAppMeasurement linker issues while the app remains on Swift 5
- Add `OTHER_LDFLAGS=$(inherited) -ObjC` to Debug and Release configs
- Match DynamicThirdParty Firebase dependency style with the working companion app setup

## Verification
- `mise x -- tuist generate --no-open`
- `xcodebuild -workspace sendadv.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build 2>&1 | xcsift -f toon -w`
- `mise x -- tuist build 2>&1 | xcsift -f toon -w`

## Release / rollback
- Dependency compatibility fix; no user flow changes
- Roll back by reverting this PR if Firebase integration regresses