### PR TITLE
fix: avoid saving discarded new rules

### DIFF
--- a/Projects/App/Sources/ViewModels/RecipientListScreenModel.swift
+++ b/Projects/App/Sources/ViewModels/RecipientListScreenModel.swift
@@ -72,12 +72,6 @@ class SARecipientListScreenModel: RecipientListScreenModel {
     func createRule(modelContext: ModelContext, undoManager: UndoManager?) -> RecipientsRule? {
         let newRule = RecipientsRule(title: "New Rule".localized(), enabled: true)
 
-        modelContext.insert(newRule)
-//        undoManager?.registerUndo(withTarget: modelContext) { context in
-//            context.delete(newRule)
-//        }
-//        try modelContext.save()
-
         return newRule
     }
 }

--- a/Projects/App/Sources/ViewModels/RuleDetailScreenModel.swift
+++ b/Projects/App/Sources/ViewModels/RuleDetailScreenModel.swift
@@ -24,6 +24,10 @@ class RuleDetailScreenModel {
 	}
 	
     func save(using context: ModelContext) {
+        if rule?.modelContext == nil, let rule {
+            context.insert(rule)
+        }
+
         rule?.title = title
         try? context.save()
         isSaved = true


### PR DESCRIPTION
## Summary
- Fixes a bug where starting a new Contact Filter and navigating back without saving still showed a new row in the Contact Filter list.
- New rules are now kept out of the SwiftData `ModelContext` until the user explicitly taps Save.
- Saving still inserts and persists the new rule normally.

## User flow
```mermaid
flowchart LR
    A[Tap add Contact Filter] --> B[Open detail screen with transient rule]
    B --> C{User action}
    C -->|Back without changes| D[Dismiss]
    C -->|Discard changes| D
    C -->|Save| E[Insert into SwiftData context]
    D --> F[List remains unchanged]
    E --> G[List shows saved rule]
```

## Changes
- `RecipientListScreenModel`
  - Stop inserting newly created rules immediately.
  - Return a transient `RecipientsRule` for the detail screen.
- `RuleDetailScreenModel`
  - Insert the rule into `ModelContext` only when saving if it has not been inserted yet.

## Verification
- `xcodebuild -workspace sendadv.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build 2>&1 | xcsift -f toon -w`
- `mise x -- tuist build 2>&1 | xcsift -f toon -w`

## Risk / rollback
- Low risk: change is limited to the new-rule creation/save boundary.
- Rollback: revert this PR to restore previous eager insertion behavior.