### PR TITLE
feat: refresh first screen design

### DIFF
--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -41,6 +41,8 @@
 "New Rule" = "New Filter";
 
 // Sending warnings
+"send.action" = "Send";
+"send.action.with.count" = "Send to %d people";
 "send.warning.batchSending" = "You are about to send message to %d recipients.\nRecipients will be separated into groups of %d for sending.";
 "send.batch.progress" = "(Batch %d/%d — %d recipients)";
 
@@ -56,6 +58,8 @@
 "rules.empty.cta" = "+ Add First Filter";
 "rules.title" = "Contact Filter List";
 "rules.add" = "Add New Filter";
+"rules.header.title" = "Your filters";
+"rules.header.summary" = "%d turned on · ready to reach people";
 
 // RuleDetailScreen
 "Rule Title" = "Filter Title";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -47,6 +47,8 @@
 "rules.empty.cta" = "+ 첫 번째 필터 추가";
 "rules.title" = "연락처 필터 목록";
 "rules.add" = "새 필터 추가";
+"rules.header.title" = "내 필터";
+"rules.header.summary" = "%d개 켜짐 · 바로 전송 준비됨";
 
 // RuleDetailScreen
 "Rule Title" = "필터 이름";
@@ -63,6 +65,8 @@
 "Permission required to acess contacts for creating recipients list" = "수신자 목록 생성을 위해 연락처 접근 권한이 필요합니다";
 
 // Sending warnings
+"send.action" = "전송";
+"send.action.with.count" = "%d개 필터로 전송";
 "send.warning.batchSending" = "메시지를 %d명의 수신자에게 전송하려고 합니다.\n수신자를 %d명씩 나누어 전송합니다.";
 "send.batch.progress" = "(배치 %d/%d — 수신자 %d명)";
 

--- a/Projects/App/Sources/Extensions/Color+.swift
+++ b/Projects/App/Sources/Extensions/Color+.swift
@@ -6,12 +6,34 @@
 //
 
 import SwiftUI
+import UIKit
 
 extension Color {
     static let background = Color("Colors/background")
     static let accent = Color("Colors/accent")
     static let title = Color("Colors/title")
     static let accentButtonLabel = Color("Colors/accentButtonLabel")
+}
+
+extension Color {
+	static let softBackground = Color.dynamic(light: "#FAF6F0", dark: "#17141F")
+	static let softSurface = Color.dynamic(light: "#FFFFFF", dark: "#242033")
+	static let softSurfaceElevated = Color.dynamic(light: "#FFFDF9", dark: "#2B263A")
+	static let softPrimaryText = Color.dynamic(light: "#2A2438", dark: "#F3F0F8")
+	static let softSecondaryText = Color.dynamic(light: "#746B82", dark: "#C8C1D4")
+	static let softAccent = Color.dynamic(light: "#5B5BD6", dark: "#7C6BF0")
+	static let softAccentLabel = Color.dynamic(light: "#FFFFFF", dark: "#F7F4FF")
+	static let softJobTint = Color.dynamic(light: "#E9E7FF", dark: "#38315E")
+	static let softDepartmentTint = Color.dynamic(light: "#FFE8DA", dark: "#553527")
+	static let softOrganizationTint = Color.dynamic(light: "#DDF4E8", dark: "#254838")
+	static let softDivider = Color.dynamic(light: "#E8DED4", dark: "#383248")
+
+	static func dynamic(light: String, dark: String) -> Color {
+		Color(uiColor: UIColor { traitCollection in
+			let hex = traitCollection.userInterfaceStyle == .dark ? dark : light
+			return UIColor(hex: hex)
+		})
+	}
 }
 
 // HEX 컬러 지원 확장
@@ -26,4 +48,17 @@ extension Color {
         let b = Double(rgb & 0xFF) / 255
         self.init(red: r, green: g, blue: b)
     }
+}
+
+private extension UIColor {
+	convenience init(hex: String) {
+		let scanner = Scanner(string: hex)
+		_ = scanner.scanString("#")
+		var rgb: UInt64 = 0
+		scanner.scanHexInt64(&rgb)
+		let r = CGFloat((rgb >> 16) & 0xFF) / 255
+		let g = CGFloat((rgb >> 8) & 0xFF) / 255
+		let b = CGFloat(rgb & 0xFF) / 255
+		self.init(red: r, green: g, blue: b, alpha: 1)
+	}
 }

--- a/Projects/App/Sources/Screens/RecipientList/RecipientListRowView.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientListRowView.swift
@@ -27,57 +27,86 @@ struct RecipientRuleRowView: View {
 		return "\(keywords[0])".localized() + " and \(keywords.count - 1) others".localized();
 	}
 
-	private var filterSummary: String {
-		var parts: [String] = [];
+	private var activeFilters: [(rawValue: String, label: String, value: String)] {
 		let targets: [(rawValue: String, labelKey: String)] = [
 			("job", "Job"),
 			("dept", "Department"),
 			("org", "Organization"),
 		];
-		for (rawValue, labelKey) in targets {
-			if let value = filterText(for: rawValue) {
-				parts.append("\(labelKey.localized()): \(value)");
-			}
+
+		return targets.compactMap { target in
+			guard let value = filterText(for: target.rawValue) else { return nil; }
+			return (target.rawValue, target.labelKey.localized(), value);
 		}
-		if parts.isEmpty {
-			return "rule.row.allContacts".localized();
+	}
+
+	private var primaryStyle: RuleCategoryStyle {
+		guard let first = activeFilters.first else { return .allContacts }
+
+		switch first.rawValue {
+		case "job": return .job
+		case "dept": return .department
+		case "org": return .organization
+		default: return .allContacts
 		}
-		return parts.joined(separator: "  |  ");
+	}
+
+	private var summaryText: String {
+		guard !activeFilters.isEmpty else { return "rule.row.allContacts".localized() }
+		return activeFilters.map(\.value).joined(separator: " · ")
 	}
 
 	var body: some View {
-		ZStack {
-			Color.background
-
-			HStack {
-				VStack(alignment: .leading, spacing: 4) {
-					if let title = rule.title, !title.isEmpty {
-						Text(title)
-							.font(.headline)
-							.foregroundStyle(Color.title)
-					} else {
-						Text("수신자 목록 생성 규칙")
-							.font(.headline)
-							.foregroundStyle(Color.title)
-					}
-
-					Text(filterSummary)
-						.font(.caption)
-						.foregroundStyle(.secondary)
-				}
-
-				Spacer()
-
-				Toggle("", isOn: Binding(
-					get: { rule.enabled },
-					set: { onToggle($0) }
-				)).padding(.trailing, 16)
+		HStack(alignment: .center, spacing: 18) {
+			ZStack {
+				RoundedRectangle(cornerRadius: 18, style: .continuous)
+					.fill(primaryStyle.background)
+				Image(systemName: primaryStyle.symbolName)
+					.font(.system(size: 25, weight: .semibold))
+					.foregroundStyle(primaryStyle.foreground)
 			}
-			.padding(.leading, 32)
-			.padding(.trailing, 16)
-			.padding(.vertical, 12)
+			.frame(width: 58, height: 58)
+
+			VStack(alignment: .leading, spacing: 5) {
+				Text(isTitleEmpty ? "New Rule".localized() : (rule.title ?? ""))
+					.font(.system(size: 22, weight: .bold, design: .rounded))
+					.foregroundStyle(Color.softPrimaryText)
+					.lineLimit(1)
+
+				Text(summaryText)
+					.font(.system(size: 16, weight: .semibold, design: .rounded))
+					.foregroundStyle(Color.softSecondaryText)
+					.lineLimit(1)
+			}
+
+			Spacer(minLength: 8)
+
+			Toggle("", isOn: Binding(
+				get: { rule.enabled },
+				set: { onToggle($0) }
+		))
+		.labelsHidden()
+		.tint(.softAccent)
+		.scaleEffect(1.12)
 		}
+		.padding(.leading, 24)
+		.padding(.trailing, 20)
+		.padding(.vertical, 18)
+		.softFriendlyCard()
+		.opacity(rule.enabled ? 1 : 0.72)
+		.accessibilityElement(children: .combine)
 	}
+}
+
+private struct RuleCategoryStyle {
+	let symbolName: String
+	let background: Color
+	let foreground: Color
+
+	static let job = RuleCategoryStyle(symbolName: "briefcase", background: .softJobTint, foreground: .softAccent)
+	static let department = RuleCategoryStyle(symbolName: "building.2", background: .softDepartmentTint, foreground: .dynamic(light: "#F2855F", dark: "#FF9D78"))
+	static let organization = RuleCategoryStyle(symbolName: "rectangle.3.group", background: .softOrganizationTint, foreground: .dynamic(light: "#2EAD6B", dark: "#67D89C"))
+	static let allContacts = RuleCategoryStyle(symbolName: "person", background: .dynamic(light: "#F4F1F4", dark: "#302B3A"), foreground: .dynamic(light: "#B7AFBE", dark: "#8F879B"))
 }
 
 struct RecipientRuleRowView_Previews: PreviewProvider {

--- a/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
@@ -29,9 +29,9 @@ private struct AccentTipViewStyle: TipViewStyle {
 						Button(action: action.handler) {
 							action.label()
 						}
-						.foregroundStyle(Color.accentButtonLabel)
+						.foregroundStyle(Color.softAccentLabel)
 						.buttonStyle(.borderedProminent)
-						.tint(.accent)
+						.tint(.softAccent)
 					}
 					Spacer()
 				}
@@ -80,6 +80,10 @@ struct RecipientRuleListScreen: View {
 	    private let addFirstFilterTip = AddFirstFilterTip()
 	    @State private var isAddFirstFilterTipVisible = false
 
+	private var enabledRuleCount: Int {
+		rules.filter(\.enabled).count
+	}
+
 	    private func presentFullAdThen(_ action: @escaping () -> Void) {
 	        guard launchCount > 1 else {
 	            action()
@@ -105,93 +109,101 @@ struct RecipientRuleListScreen: View {
         }
     }
 
-    var body: some View {
-        ZStack {
-            Color.background
-                .edgesIgnoringSafeArea(.all)
+	var body: some View {
+		ZStack {
+			Color.softBackground
+				.ignoresSafeArea()
 
-            List {
-                Section {
-                    if !rules.isEmpty && !isAdFree {
-                        NativeAdRowView()
-                    }
-                    ForEach(rules) { rule in
-                        RecipientRuleRowView(rule: rule) { isEnabled in
-                            toggleRule(rule, isEnabled: isEnabled)
-                        }
-                        .onTapGesture {
-                            state = .editingRule(rule)
-                        }
-                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                            Button(role: .destructive) {
-                                deleteRule(rule)
-                            } label: {
-                                Label("Delete".localized(), systemImage: "trash")
-                            }
-                        }
-                    }
-                }
-                .listRowBackground(Color.clear)
-            }
-            .listStyle(.plain)
-            .overlay {
-                if rules.isEmpty {
-                    EmptyStateView {
-                        state = .creatingRule
-                    }
-                }
-            }
+			ScrollView {
+				LazyVStack(spacing: 12) {
+					RuleListHeaderView(enabledCount: enabledRuleCount)
+						.padding(.bottom, 0)
 
-            // 전송 버튼
-            if !rules.isEmpty {
-                VStack {
-                    Spacer()
-                    HStack(alignment: .bottom, spacing: 12) {
-                        Spacer()
-                        WatchAdButton(isAdFree: $isAdFree) {
-                            showAdFreeToast = true
-                            Task {
-                                try? await Task.sleep(for: .seconds(2))
-                                showAdFreeToast = false
-                            }
-                        }
-                        SendButton {
-                            onSendMessage()
-                        }
-                    }
-                    .padding(.trailing, 20)
-                    .padding(.bottom, 20)
-                }
-            }
+					ForEach(rules) { rule in
+						RecipientRuleRowView(rule: rule) { isEnabled in
+							toggleRule(rule, isEnabled: isEnabled)
+						}
+						.onTapGesture {
+							state = .editingRule(rule)
+						}
+						.contextMenu {
+							Button(role: .destructive) {
+								deleteRule(rule)
+							} label: {
+								Label("Delete".localized(), systemImage: "trash")
+							}
+						}
+					}
 
-            // 광고 없음 토스트
-            if showAdFreeToast {
-                VStack {
-                    Spacer()
-                    Text("watch.ad.toast".localized())
-                        .font(.subheadline.weight(.medium))
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 10)
-                        .background(Color.accent.opacity(0.9), in: Capsule())
-                        .padding(.bottom, 90)
-                }
-                .transition(.opacity.combined(with: .move(edge: .bottom)))
-            }
-        }
-        .navigationTitle("rules.title".localized())
-        .navigationBarTitleDisplayMode(.large)
+					if !rules.isEmpty && !isAdFree {
+						NativeAdRowView()
+							.padding(.top, 58)
+					}
+				}
+				.padding(.top, 0)
+				.padding(.horizontal, 30)
+				.padding(.bottom, 146)
+			}
+			.scrollIndicators(.hidden)
+			.overlay {
+				if rules.isEmpty {
+					EmptyStateView {
+						state = .creatingRule
+					}
+				}
+			}
+
+			// 전송 버튼
+			if !rules.isEmpty {
+				VStack {
+					Spacer()
+					HStack(alignment: .center, spacing: 14) {
+						WatchAdButton(isAdFree: $isAdFree) {
+							showAdFreeToast = true
+							Task {
+								try? await Task.sleep(for: .seconds(2))
+								showAdFreeToast = false
+							}
+						}
+						SendButton(title: String(format: "send.action.with.count".localized(), enabledRuleCount)) {
+							onSendMessage()
+						}
+					}
+					.frame(maxWidth: .infinity)
+					.padding(.horizontal, 30)
+					.padding(.bottom, 24)
+				}
+			}
+
+			// 광고 없음 토스트
+			if showAdFreeToast {
+				VStack {
+					Spacer()
+					Text("watch.ad.toast".localized())
+						.font(.subheadline.weight(.medium))
+						.foregroundStyle(Color.softAccentLabel)
+						.padding(.horizontal, 16)
+						.padding(.vertical, 10)
+						.background(Color.softAccent.opacity(0.95), in: Capsule())
+						.padding(.bottom, 90)
+				}
+				.transition(.opacity.combined(with: .move(edge: .bottom)))
+			}
+		}
+		.navigationTitle("")
+		.toolbarVisibility(.hidden, for: .navigationBar)
+		.navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
-                    if isAddFirstFilterTipVisible {
-                        addFirstFilterTip.logActionTaken()
-                    }
-                    state = .creatingRule
-                } label: {
-                    Image(systemName: "plus")
-                }
-                .tint(Color.accent)
+				Button {
+					if isAddFirstFilterTipVisible {
+						addFirstFilterTip.logActionTaken()
+					}
+					state = .creatingRule
+				} label: {
+					Image(systemName: "plus")
+				}
+				.tint(Color.softAccent)
                 .popoverTip(addFirstFilterTip, arrowEdge: .top) { _ in
                     addFirstFilterTip.logActionTaken()
                     state = .creatingRule
@@ -345,9 +357,9 @@ struct RecipientRuleListScreen: View {
 //        .onChange(of: state, handleStateChange)
         .overlay {
             if isPreparingMessageView {
-                ProgressView()
-                    .progressViewStyle(CircularProgressViewStyle(tint: .accent))
-                    .scaleEffect(1.5)
+	                ProgressView()
+	                    .progressViewStyle(CircularProgressViewStyle(tint: .softAccent))
+	                    .scaleEffect(1.5)
             }
         }
 
@@ -474,6 +486,26 @@ struct RecipientRuleListScreen: View {
 }
 
 
+private struct RuleListHeaderView: View {
+	let enabledCount: Int
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 8) {
+			Text("rules.header.title".localized())
+				.font(.system(size: 40, weight: .bold, design: .rounded))
+				.foregroundStyle(Color.softPrimaryText)
+				.tracking(-1.2)
+
+			Text(String(format: "rules.header.summary".localized(), enabledCount))
+				.font(.title3.weight(.bold))
+				.foregroundStyle(Color.softSecondaryText)
+		}
+		.frame(maxWidth: .infinity, alignment: .leading)
+	}
+}
+
+
+
 
 #Preview {
     let config = ModelConfiguration(isStoredInMemoryOnly: true)
@@ -495,4 +527,3 @@ struct RecipientRuleListScreen: View {
     .modelContainer(container)
     .environmentObject(adManager)
 }
-

--- a/Projects/App/Sources/Views/NativeAdRowView.swift
+++ b/Projects/App/Sources/Views/NativeAdRowView.swift
@@ -11,78 +11,90 @@ import SwiftUI
 struct NativeAdRowView: View {
     @EnvironmentObject private var adManager: SwiftUIAdManager
 
-    var body: some View {
-        NativeAdSwiftUIView() { nativeAd in
-            Group {
-                if let ad = nativeAd {
-                    HStack(spacing: 12) {
-                        MediaViewSwiftUIView(mediaContent: ad.mediaContent)
-                            .frame(width: 64, height: 64)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text(ad.headline ?? "")
-                                .font(.headline)
-                            if let body = ad.body {
-                                Text(body)
-                                    .font(.subheadline)
-                                    .foregroundStyle(.secondary)
-                            }
-                            if let advertiser = ad.advertiser {
-                                Text(advertiser)
-                                    .font(.caption)
-                                    .foregroundStyle(.tertiary)
-                            }
-                        }.task {
-                            await adManager.requestAppTrackingIfNeed()
+	var body: some View {
+		NativeAdSwiftUIView() { nativeAd in
+			Group {
+				if let ad = nativeAd {
+					HStack(spacing: 18) {
+						MediaViewSwiftUIView(mediaContent: ad.mediaContent)
+							.frame(width: 72, height: 72)
+							.clipShape(.rect(cornerRadius: 12, style: .continuous))
+						VStack(alignment: .leading, spacing: 6) {
+							Text(ad.headline ?? "")
+								.font(.headline.weight(.bold))
+								.foregroundStyle(Color.softPrimaryText)
+								.lineLimit(2)
+							if let body = ad.body {
+								Text(body)
+									.font(.subheadline)
+									.foregroundStyle(Color.softSecondaryText)
+									.lineLimit(2)
+							}
+							if let advertiser = ad.advertiser {
+								Text(advertiser)
+									.font(.caption)
+									.foregroundStyle(Color.softSecondaryText.opacity(0.7))
+							}
+						}.task {
+							await adManager.requestAppTrackingIfNeed()
                         }
-                        Spacer()
-                        if let cta = ad.callToAction {
-                            Button(cta) {}
-                                .buttonStyle(.borderedProminent)
-                        }
-                    }
-                } else {
-                    HStack(spacing: 12) {
-                        Image("otherapp")
-                            .renderingMode(.original)
-                            .resizable()
+						Spacer()
+						if let cta = ad.callToAction {
+							Button(cta) {}
+								.font(.headline.weight(.bold))
+								.foregroundStyle(.white)
+								.padding(.horizontal, 18)
+								.padding(.vertical, 12)
+								.background(.black, in: .capsule)
+						}
+					}
+				} else {
+					HStack(spacing: 18) {
+						Image("otherapp")
+							.renderingMode(.original)
+							.resizable()
                             .scaledToFit()
                             .aspectRatio(contentMode: .fill)
-                            .frame(width: 64, height: 64)
-                            .clipShape(RoundedRectangle(cornerRadius: 8))
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text("ads header".localized())
-                                .font(.headline)
-                            Text("ads description".localized())
-                                .font(.subheadline)
-                                .foregroundStyle(.secondary)
-                        }
-                        Spacer()
-                        Button("ads action".localized()) {
-                            //
-                        }
-                        .buttonStyle(.borderedProminent)
-                    }.onTapGesture {
+							.frame(width: 72, height: 72)
+							.clipShape(.rect(cornerRadius: 12, style: .continuous))
+						VStack(alignment: .leading, spacing: 6) {
+							Text("ads header".localized())
+								.font(.headline.weight(.bold))
+								.foregroundStyle(Color.softPrimaryText)
+							Text("ads description".localized())
+								.font(.subheadline)
+								.foregroundStyle(Color.softSecondaryText)
+								.lineLimit(3)
+						}
+						Spacer()
+						Button("ads action".localized()) {
+							//
+						}
+						.font(.headline.weight(.bold))
+						.foregroundStyle(.white)
+						.padding(.horizontal, 18)
+						.padding(.vertical, 12)
+						.background(.black, in: .capsule)
+					}.onTapGesture {
                         guard let url = URL(string: "https://apps.apple.com/us/developer/young-jun-lee/id1225480114") else {
                             return
                         }
                         UIApplication.shared.open(url, options: [.universalLinksOnly : false], completionHandler: nil)
                     }
-                }
-            }
-            .frame(height: 120)
-            .background(Color(.secondarySystemBackground))
-            .clipShape(RoundedRectangle(cornerRadius: 10))
-            // 'Ad' badge required by AdMob policy
-            .overlay(alignment: .topLeading) {
-                if nativeAd != nil {
-                    AdMarkView()
-                }
-            }
-            .padding(.vertical, 4)
-            .padding(.horizontal, 16)
-        }
-    }
+				}
+			}
+			.padding(16)
+			.frame(minHeight: 118)
+			.background(Color.dynamic(light: "#F0F0F7", dark: "#252331"), in: .rect(cornerRadius: 18, style: .continuous))
+			// 'Ad' badge required by AdMob policy
+			.overlay(alignment: .topLeading) {
+				if nativeAd != nil {
+					AdMarkView()
+						.offset(x: 8, y: 8)
+				}
+			}
+		}
+	}
 }
 
 // MARK: - Ad Mark

--- a/Projects/App/Sources/Views/RecipientComponents.swift
+++ b/Projects/App/Sources/Views/RecipientComponents.swift
@@ -15,43 +15,55 @@ struct EmptyStateView: View {
 	let onAddTapped: () -> Void
 
 	var body: some View {
-		VStack(spacing: 20) {
-			Image(systemName: "person.3.fill")
-				.font(.system(size: 60))
-				.foregroundStyle(.secondary)
+		VStack(spacing: 22) {
+			ZStack {
+				Circle()
+					.fill(Color.softAccent.opacity(0.12))
+					.frame(width: 92, height: 92)
+
+				Image(systemName: "person.crop.circle.badge.plus")
+					.font(.system(size: 42, weight: .semibold))
+					.foregroundStyle(Color.softAccent)
+			}
 
 			Text("rules.empty".localized())
-				.font(.title2)
-				.foregroundStyle(.secondary)
+				.font(.title2.weight(.bold))
+				.foregroundStyle(Color.softPrimaryText)
 
 			Text("rules.empty.description".localized())
 				.font(.body)
-				.foregroundStyle(.secondary)
+				.foregroundStyle(Color.softSecondaryText)
+				.multilineTextAlignment(.center)
+				.padding(.horizontal, 12)
 
 			Button(action: onAddTapped) {
 				Text("rules.empty.cta".localized())
 			}
-			.buttonStyle(.borderedProminent)
-			.tint(.accent)
+			.buttonStyle(SoftFriendlyPrimaryButtonStyle())
 		}
+		.padding(28)
+		.frame(maxWidth: 340)
+		.softFriendlyCard()
+		.padding(.horizontal, 24)
 	}
 }
 
 
 
 struct SendButton: View {
+	var title: String = "send.action".localized()
 	let action: () -> Void
 	
 	var body: some View {
 		Button(action: action) {
-			Image(systemName: "paperplane.fill")
-				.font(.title2)
-				.foregroundColor(.black)
-				.frame(width: 56, height: 56)
-				.background(Color.yellow)
-				.clipShape(Circle())
-				.shadow(radius: 4)
+			HStack(spacing: 12) {
+				Image(systemName: "paperplane.fill")
+					.font(.headline.weight(.bold))
+				Text(title)
+			}
 		}
+		.buttonStyle(SoftFriendlyPrimaryButtonStyle())
+		.accessibilityLabel(title)
 	}
 }
 
@@ -86,4 +98,3 @@ struct RuleEditView: View {
 			}
 	}
 } 
-

--- a/Projects/App/Sources/Views/SoftFriendlyStyle.swift
+++ b/Projects/App/Sources/Views/SoftFriendlyStyle.swift
@@ -1,0 +1,38 @@
+//
+//  SoftFriendlyStyle.swift
+//  App
+//
+//  Created by OpenAI on 6/28/26.
+//
+
+import SwiftUI
+
+struct SoftFriendlyCardModifier: ViewModifier {
+	func body(content: Content) -> some View {
+		content
+			.background(Color.softSurface, in: .rect(cornerRadius: 28, style: .continuous))
+			.overlay {
+				RoundedRectangle(cornerRadius: 28, style: .continuous)
+					.stroke(Color.white.opacity(0.35), lineWidth: 1)
+			}
+			.shadow(color: .black.opacity(0.04), radius: 24, x: 0, y: 14)
+	}
+}
+
+struct SoftFriendlyPrimaryButtonStyle: ButtonStyle {
+	func makeBody(configuration: Configuration) -> some View {
+		configuration.label
+			.font(.headline.weight(.bold))
+			.foregroundStyle(Color.softAccentLabel)
+			.frame(maxWidth: .infinity, minHeight: 58, maxHeight: 58)
+			.background(Color.softAccent, in: .capsule)
+			.shadow(color: Color.softAccent.opacity(configuration.isPressed ? 0.12 : 0.26), radius: configuration.isPressed ? 5 : 18, x: 0, y: configuration.isPressed ? 3 : 12)
+			.scaleEffect(configuration.isPressed ? 0.97 : 1)
+	}
+}
+
+extension View {
+	func softFriendlyCard() -> some View {
+		modifier(SoftFriendlyCardModifier())
+	}
+}

--- a/Projects/App/Sources/Views/WatchAdButton.swift
+++ b/Projects/App/Sources/Views/WatchAdButton.swift
@@ -22,13 +22,26 @@ struct WatchAdButton: View {
 			}) {
 				ZStack {
 					Circle()
-						.fill(Color(.tertiarySystemBackground))
-						.shadow(color: .black.opacity(0.25), radius: 6, x: 0, y: 3)
+						.fill(Color.softSurfaceElevated)
+						.overlay {
+							Circle()
+								.stroke(Color.softDivider.opacity(0.75), lineWidth: 1)
+						}
+						.shadow(color: .black.opacity(0.08), radius: 12, x: 0, y: 6)
 					Image(systemName: "gift.fill")
 						.font(.system(size: 18, weight: .medium))
-						.foregroundStyle(Color.accent)
+						.foregroundStyle(Color.softAccent)
 				}
-				.frame(width: 44, height: 44)
+				.frame(width: 64, height: 64)
+				.overlay(alignment: .topTrailing) {
+					Text("1h")
+						.font(.caption2.weight(.bold))
+						.foregroundStyle(.white)
+						.padding(.horizontal, 7)
+						.padding(.vertical, 4)
+						.background(Color.dynamic(light: "#F2855F", dark: "#FF9D78"), in: .capsule)
+						.offset(x: 7, y: -6)
+				}
 			}
 			.buttonStyle(.plain)
 			.accessibilityLabel("watch.ad.accessibility.label".localized())

--- a/design.md
+++ b/design.md
@@ -1,0 +1,412 @@
+# SendAdv Soft Friendly Design Plan
+
+## Goal and success criteria
+
+Apply the new **Soft Friendly** visual direction from `design/project/SendAdv Soft Friendly.dc.html` to the iOS app.
+
+Success means:
+- The app uses one cohesive design system with matching **Light** and **Dark** appearances.
+- The main Contact Filter flows match the prototype intent:
+  - filter list
+  - empty state
+  - build/edit filter
+  - sub-filter item picker
+  - send confirmation / handoff to Messages
+- Existing behavior remains unchanged unless explicitly listed in this plan.
+- Accessibility, localization, SwiftData behavior, ads, and message sending continue to work.
+
+## Source design interpretation
+
+Primary source:
+- `design/project/SendAdv Soft Friendly.dc.html`
+
+Important clarification:
+- The prototype contains **one design direction**: `Soft Friendly`.
+- The two rows are not separate design options.
+- They are the same design in two appearances:
+  - `Soft Friendly · Light`
+  - `Soft Friendly · Dark`
+
+Reference-only source:
+- `design/project/SendAdv Filter Designs.dc.html`
+  - Contains earlier directions A/B/C.
+  - Direction C is the ancestor of the final Soft Friendly concept.
+  - Use only if a detail is missing from the primary file.
+
+## Design language
+
+Tone:
+- Warm
+- Rounded
+- Friendly
+- Calm but confident
+- More guided than the current plain list UI
+
+Core visual ideas:
+- Soft warm background instead of flat system background.
+- Rounded white / dark-violet cards with gentle elevation.
+- Indigo primary action color.
+- Category-coded filter icons:
+  - Job: indigo
+  - Department: peach
+  - Organization: green
+  - Disabled / Any: muted lavender-gray
+- Large friendly titles and compact explanatory subtitles.
+- Bottom primary action for sending, with a secondary reward/ad-free button.
+
+## Design tokens
+
+### Color tokens
+
+| Role | Light | Dark | Usage |
+|---|---:|---:|---|
+| App background | `#FAF6F0` | `#17141F` | Root screen background |
+| Primary text | `#2A2438` | `#F3F0F8` | Titles, important labels |
+| Secondary text | `#9B93A8` | `#9A93A8` | Subtitles, helper text |
+| Card surface | `#FFFFFF` | `#221E2E` | Rows, panels, fields |
+| Native ad surface | `#F0F0F7` | `#252331` | Native ad card after filter cards |
+| Muted surface | `#F0EEF4` | `#1C1926` | Disabled cards / neutral states |
+| Primary accent | `#5B5BD6` | `#7C6BF0` | Save, selected, send button |
+| Job tint bg | `#EEF0FF` | `#272338` | Job icon container |
+| Job tint fg | `#5B5BD6` | `#9B8BF5` | Job icon / selected text |
+| Department tint bg | `#FFF0E8` | `#2E2622` | Department icon container |
+| Department tint fg | `#E8895B` | `#E8A07B` | Department icon / selected text |
+| Organization tint bg | `#E8F8EF` | `#1E2D26` | Organization icon container |
+| Organization tint fg | `#2BA55D` | `#5FCB8A` | Organization icon / selected text |
+| Divider | `#F3F0F6` | `#2C2839` | Item list separators |
+| Off toggle track | `#E6E2EC` | `#332E42` | Disabled toggles |
+
+### Typography
+
+Use SF Pro through SwiftUI system fonts.
+
+| Role | Prototype | SwiftUI recommendation |
+|---|---:|---|
+| Main screen title | Large rounded title | `.system(size: 40, weight: .bold, design: .rounded)` |
+| Main screen subtitle | Bold status text | `.title3.weight(.bold)` |
+| Filter card title | Large rounded row title | `.system(size: 22, weight: .bold, design: .rounded)` |
+| Filter card subtitle | Compact rounded summary | `.system(size: 16, weight: .semibold, design: .rounded)` |
+| Detail title | 16 pt, weight 700 | `.headline.weight(.bold)` |
+| Field value | 22 pt, weight 700 | `.title3.weight(.bold)` |
+| Body helper | 13–15 pt | `.footnote` / `.subheadline` |
+| Primary button | 17 pt, weight 700 | `.headline.weight(.bold)` |
+
+### Radius and spacing
+
+| Element | Radius / size |
+|---|---:|
+| Filter list card | 28 pt |
+| Detail/filter cards | 20 pt |
+| Search field | 14 pt |
+| List group panel | 18 pt |
+| Icon tile | 18 pt radius, 58 pt size |
+| Bottom send button | 29 pt capsule radius, 58 pt height |
+| Reward/ad-free button | 64 pt circle |
+| Native ad card | 18 pt radius, minimum 118 pt height |
+| Send confirmation sheet | 30 pt top corners |
+
+### Elevation
+
+Light mode:
+- Cards: `0 6 18 rgba(91,91,214,0.07)`
+- Reward button: `0 10 24 rgba(91,91,214,0.16)`
+- Send button: `0 12 28 rgba(91,91,214,0.34)`
+
+Dark mode:
+- Cards: gentle black elevation, usually `rgba(0,0,0,0.30–0.40)`.
+- Avoid bright white shadows.
+
+## Screen specifications
+
+### 1. Contact Filter List
+
+Current app file candidates:
+- `RecipientRuleListScreen.swift`
+- `RecipientListRowView.swift`
+- `RecipientComponents.swift`
+- `WatchAdButton.swift`
+
+Design requirements:
+- Replace the current plain list look with warm background and rounded cards.
+- Use an in-screen custom header instead of the default large navigation title.
+- Prefer `ScrollView` + `LazyVStack` over `List` for this screen to avoid system list insets and to match the prototype spacing.
+- Header copy should communicate status:
+  - Example: `Your filters`
+  - Subtitle: `3 turned on · ready to reach 24 people`
+- Each filter row contains:
+  - category-colored icon tile
+  - title
+  - concise filter summary
+  - enabled toggle
+- Disabled rows should appear muted with reduced opacity.
+- Native Ad is still part of the product and must not be removed:
+  - Do **not** place it between the header and the first filter card.
+  - Do **not** place it near the fixed bottom CTA.
+  - Place it after all filter cards as a secondary card with enough top spacing.
+  - Align it to the same horizontal layout grid as the filter cards.
+  - Avoid extra parent clipping; the `Ad` badge must not be cropped.
+- Bottom action area:
+  - fixed circular reward/ad-free button on the left
+  - large primary send button on the right
+  - layout rule: `HStack(spacing: 14) { giftButton.fixedSize; sendButton.fillRemainingWidth }`
+  - no leading `Spacer()` before the gift button
+  - CTA button background should fill the remaining width exactly; avoid adding horizontal padding after `frame(maxWidth: .infinity)`.
+- Empty state should be centered and friendly:
+  - large rounded illustration container
+  - title: `No filters yet`
+  - helper text explaining grouping by job/department/organization
+  - primary CTA: `Add your first filter`
+
+Implementation notes from first-screen iteration:
+- Initial `design.md` interpretation was too chip/card-oriented. The actual first-screen prototype is:
+  - large custom header,
+  - large rounded filter cards,
+  - left icon tile + title/subtitle + right toggle,
+  - bottom fixed reward button + fill-width send pill.
+- Native Ad should be visually secondary, but retained.
+- Because `ScrollView` does not support `swipeActions`, delete can be exposed via context menu unless a custom swipe action is implemented later.
+- Current send CTA count is based on enabled filter count. True recipient count like `24 people` requires async contact filtering and should be implemented separately.
+
+### 2. Build / Edit Filter
+
+Current app file candidates:
+- `RuleDetailScreen.swift`
+- `RuleDetailScreenModel.swift`
+
+Design requirements:
+- Use custom compact top bar instead of relying only on default navigation title.
+- Back button: circular surface button.
+- Center title: `New filter` or edit title.
+- Save action: primary accent text.
+- Name field is a rounded card:
+  - label: `Give it a name`
+  - title value in large bold text
+- Filter categories shown as rounded cards:
+  - Job
+  - Department
+  - Organization
+- Each category card includes:
+  - colored icon tile
+  - category title
+  - current selection summary
+  - chevron
+
+### 3. Sub-filter Item Picker
+
+Current app file candidates:
+- `RuleFilterScreen.swift`
+- `RuleFilterScreenModel.swift`
+
+Design requirements:
+- Top bar includes:
+  - circular back button
+  - category icon + category title
+  - Done action
+- Helper copy:
+  - `Pick which job titles this filter includes`
+  - Adapt wording by category.
+- Add search field:
+  - Rounded surface
+  - Search icon
+  - Placeholder changes by category, e.g. `Search titles`
+- Select all row:
+  - title: `Select all titles`
+  - subtitle: `Match everyone regardless of title`
+  - toggle
+- Section summary row:
+  - left: item count, e.g. `7 titles`
+  - right: selected count, e.g. `3 selected`
+- Item list:
+  - rounded grouped panel
+  - selected rows use subtle accent background
+  - selected indicator is filled circle with checkmark
+  - unselected indicator is outlined circle
+
+### 4. Send Confirmation / Messages Handoff
+
+Current app file candidates:
+- `RecipientRuleListScreen.swift`
+- `MessageComposerView` integration
+
+Design requirements:
+- Before opening Messages, show a bottom confirmation sheet.
+- Background filter list appears dimmed / de-emphasized.
+- Sheet content:
+  - handle bar
+  - Messages-style icon tile
+  - title: `Ready to send?`
+  - explanation with recipient count highlighted
+  - small recipient preview stack
+  - primary button: `Open Messages`
+  - secondary text action: `Not now`
+- Keep current batching and contact permission behavior intact.
+
+## Flow diagram
+
+```mermaid
+flowchart LR
+    A[Contact Filter List] --> B{Has filters?}
+    B -->|No| C[Empty State]
+    C --> D[Add First Filter]
+    B -->|Yes| E[Filter Cards]
+    E --> F[Edit / Build Filter]
+    F --> G[Sub-filter Picker]
+    G --> F
+    E --> H[Send Button]
+    H --> I[Send Confirmation Sheet]
+    I -->|Open Messages| J[Message Composer]
+    I -->|Not now| A
+```
+
+## Implementation plan
+
+### Milestone 1 — Design system foundation
+
+Owner: iOS developer
+
+Deliverables:
+- Add semantic SwiftUI colors for the Soft Friendly palette.
+- Add reusable surface/card/button modifiers.
+- Add category style helper for Job / Department / Organization / Any.
+- Ensure colors have Light and Dark variants.
+
+Suggested files:
+- `Projects/App/Sources/Extensions/Color+.swift`
+- `Projects/App/Resources/Assets.xcassets/Colors/`
+- New file: `Projects/App/Sources/Views/Design/SoftFriendlyTheme.swift`
+
+Verification:
+- Light/Dark previews render with correct colors.
+- Existing app compiles without changing behavior.
+
+### Milestone 2 — Filter list refresh
+
+Owner: iOS developer
+
+Deliverables:
+- Redesign `RecipientRuleListScreen` header, filter cards, empty state, Native Ad position, and bottom send area.
+- Redesign `RecipientRuleRowView` as a large Soft Friendly filter card.
+- Redesign `NativeAdRowView` as a secondary Soft Friendly ad card while preserving the AdMob `Ad` badge.
+- Preserve toggles, ad/reward behavior, Tips, and message sending.
+- Delete behavior: preserve deletion through context menu for this first-screen PR; consider custom swipe deletion in a follow-up if required.
+
+Suggested files:
+- `RecipientRuleListScreen.swift`
+- `RecipientListRowView.swift`
+- `RecipientComponents.swift`
+- `WatchAdButton.swift`
+- `NativeAdRowView.swift`
+
+Verification:
+- Existing filters display correctly.
+- Empty state CTA creates a new filter.
+- Toggle persists.
+- Delete via context menu persists.
+- Reward button still grants ad-free state.
+- Native Ad displays below filter cards and the `Ad` badge is not cropped.
+- Bottom CTA has equal outer horizontal margins; gift button is fixed width and send button fills the remaining width.
+
+### Milestone 3 — Filter editor refresh
+
+Owner: iOS developer
+
+Deliverables:
+- Redesign `RuleDetailScreen` with title field card and category cards.
+- Keep unsaved-change confirmation behavior.
+- Keep the recent fix: new filters are only inserted into SwiftData on Save.
+
+Suggested files:
+- `RuleDetailScreen.swift`
+- `RuleDetailScreenModel.swift`
+
+Verification:
+- New → Back without saving does not create a row.
+- New → Save creates a row.
+- Edit → Save updates existing row.
+- Edit → Discard keeps original values.
+
+### Milestone 4 — Sub-filter picker refresh
+
+Owner: iOS developer
+
+Deliverables:
+- Add search UI and selected count.
+- Redesign selected/unselected item rows.
+- Preserve selection and Done behavior.
+
+Suggested files:
+- `RuleFilterScreen.swift`
+- `RuleFilterScreenModel.swift`
+
+Verification:
+- Search filters visible options without changing saved values until Done.
+- Select all works.
+- Selected count is accurate.
+
+### Milestone 5 — Send confirmation sheet
+
+Owner: iOS developer
+
+Deliverables:
+- Add confirmation sheet before launching Messages.
+- Preserve current permission checks, no-rule warnings, batching, full-screen ad behavior, and review request behavior.
+
+Suggested files:
+- `RecipientRuleListScreen.swift`
+- New reusable component: `SendConfirmationSheet.swift`
+
+Verification:
+- Tapping Send shows confirmation sheet.
+- `Open Messages` launches current composer flow.
+- `Not now` dismisses only the sheet.
+- Batch sending still works.
+
+## Dependencies and critical path
+
+Critical path:
+1. Design system foundation
+2. Filter list cards and empty state
+3. Filter editor cards
+4. Sub-filter picker
+5. Send confirmation sheet
+6. Full build and simulator smoke test
+
+Parallelization:
+- After Milestone 1, filter list and filter editor can proceed in parallel.
+- Sub-filter picker can proceed after category style helper is available.
+- Send confirmation can proceed independently as long as the existing send function contract is preserved.
+
+## Risks and mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Visual refresh accidentally changes persistence behavior | High | Keep model/view-model logic unchanged except where explicitly needed |
+| Dark mode colors lack contrast | Medium | Test with iOS accessibility contrast and real Dark Mode previews |
+| Send flow regressions | High | Wrap existing `onSendMessage()` rather than rewriting contact loading |
+| Ad/reward button behavior breaks | Medium | Reuse existing `WatchAdButton` state and only change presentation |
+| Large contact lists make picker slow | Medium | Add search/filtering efficiently and avoid expensive recomputation in body |
+
+## Verification checklist
+
+- [ ] `mise x -- tuist generate --no-open`
+- [ ] `xcodebuild -workspace sendadv.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build 2>&1 | xcsift -f toon -w`
+- [ ] `mise x -- tuist build 2>&1 | xcsift -f toon -w`
+- [ ] Light Mode manual smoke test
+- [ ] Dark Mode manual smoke test
+- [ ] Empty state → Add first filter
+- [ ] New filter → Back without saving → no new row
+- [ ] New filter → Save → row appears
+- [ ] Edit filter → change title/category → Save persists
+- [ ] Sub-filter picker → Select all / individual selection / Done
+- [ ] Send button → confirmation sheet → Open Messages
+- [ ] Contact permission denied path
+- [ ] No active filters warning path
+- [ ] Reward/ad-free button path
+
+## Release checklist
+
+- [ ] Feature branch PR with screenshots or simulator recordings
+- [ ] PR body includes before/after user flow and accessibility notes
+- [ ] Build & Test workflow passes
+- [ ] TestFlight smoke test before App Store release
+- [ ] Rollback plan: revert design PR; no data migration required


### PR DESCRIPTION
## Goal and success criteria
- Refresh the first Contact Filter List screen to match the Soft Friendly design direction.
- Preserve existing core behavior: filter toggle, edit navigation, message sending, reward/ad-free button, and Native Ad display.
- Document the finalized first-screen design decisions in design.md.

## What changed
- Added Soft Friendly semantic colors and reusable card/button styles.
- Rebuilt the first screen with a custom header, rounded filter cards, icon tiles, and fixed bottom CTA.
- Updated the bottom action layout so the gift button is fixed width and the send CTA fills the remaining width.
- Restyled Native Ad as a secondary card placed after filter cards, without cropping the Ad badge.
- Updated EN/KO strings for the send CTA and header copy.
- Added design.md with the corrected first-screen implementation notes and follow-up plan.

## User flow

```mermaid
flowchart TD
  A[Open Contact Filter List] --> B[See custom header and filter cards]
  B --> C{Tap filter card?}
  C -->|Yes| D[Open filter editor]
  C -->|No| E{Tap send CTA?}
  E -->|Yes| F[Existing send flow]
  B --> G[Native Ad shown after filter cards]
  B --> H[Gift button can activate ad-free state]
```

## Verification
- [x] mise x -- tuist generate --no-open
- [x] xcodebuild -workspace sendadv.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build 2>&1 | xcsift -f toon -w
- [x] mise x -- tuist build 2>&1 | xcsift -f toon -w
- [x] Manual visual iteration against supplied first-screen screenshots

## Notes
- Native Ad is intentionally retained and placed after filter cards as secondary content.
- Deletion is available via context menu in this first-screen refresh because the screen now uses ScrollView/LazyVStack for accurate design spacing. Custom swipe deletion can be added in a follow-up if needed.
- The send CTA count currently uses enabled filter count; true recipient count requires async contact filtering and should be handled separately.

## Rollback
- Revert this PR. No data migration is involved.

## Result
<img width="404" height="812" alt="스크린샷 2026-06-29 오후 5 21 51" src="https://github.com/user-attachments/assets/2d0efaa9-c357-45bc-87fb-cdefb45fddc5" />
