### PR TITLE
feat: refresh rule detail design

### DIFF
--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -64,10 +64,15 @@
 // RuleDetailScreen
 "Rule Title" = "Filter Title";
 "Enter rule title" = "Enter filter title";
+"rule.detail.title.new" = "New filter";
+"rule.detail.name.label" = "Give it a name";
+"rule.detail.match.section" = "Who should match?";
+"Anyone" = "Anyone";
 "unsaved.changes.title" = "Save Changes?";
 "unsaved.changes.discard" = "Don't Save";
 
 // Common actions
+"Back" = "Back";
 "Edit" = "Edit";
 "Delete" = "Delete";
 

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -53,10 +53,15 @@
 // RuleDetailScreen
 "Rule Title" = "필터 이름";
 "Enter rule title" = "필터 이름을 입력하세요";
+"rule.detail.title.new" = "새 필터";
+"rule.detail.name.label" = "이름 지정";
+"rule.detail.match.section" = "누가 포함되나요?";
+"Anyone" = "누구나";
 "unsaved.changes.title" = "변경사항을 저장하시겠습니까?";
 "unsaved.changes.discard" = "저장 안 함";
 
 // Common actions
+"Back" = "뒤로";
 "Edit" = "편집";
 "Delete" = "삭제";
 

--- a/Projects/App/Sources/Screens/RuleDetailScreen.swift
+++ b/Projects/App/Sources/Screens/RuleDetailScreen.swift
@@ -17,6 +17,7 @@ struct RuleDetailScreen: View {
 	@State private var viewModel: RuleDetailScreenModel
 	@State private var selectedFilter: RecipientsFilter?
 	@State private var showDiscardConfirmation: Bool = false
+	@FocusState private var isTitleFocused: Bool
 	
 	init(rule: RecipientsRule?) {
 		_viewModel = State(initialValue: RuleDetailScreenModel(rule: rule))
@@ -24,83 +25,67 @@ struct RuleDetailScreen: View {
 	
 	var body: some View {
 		ZStack {
-            Color.background
-				.edgesIgnoringSafeArea(.all)
-			
-			VStack(spacing: 20) {
-				// 제목 입력 필드
-				VStack(alignment: .leading, spacing: 8) {
-					Text("Rule Title".localized())
-						.font(.headline)
-						.foregroundColor(.title)
-					
-					TextField("Enter rule title".localized(), text: $viewModel.title)
-						.textFieldStyle(RoundedBorderTextFieldStyle())
-						.font(.body)
-				}
-				.padding(.horizontal, 20)
-				.padding(.top, 20)
-				
-				// 필터 목록
-				VStack(spacing: 16) {
-					FilterRowView(
-						title: "Job".localized(),
-						subtitle: viewModel.getJobFilterText(),
-						icon: "person.2.fill"
-					) {
-						selectedFilter = viewModel.getOrCreateFilter(for: "job")
-					}
-					
-					FilterRowView(
-						title: "Department".localized(),
-						subtitle: viewModel.getDepartmentFilterText(),
-						icon: "building.2.fill"
-					) {
-						selectedFilter = viewModel.getOrCreateFilter(for: "dept")
-					}
-					
-					FilterRowView(
-						title: "Organization".localized(),
-						subtitle: viewModel.getOrganizationFilterText(),
-						icon: "building.fill"
-					) {
-						selectedFilter = viewModel.getOrCreateFilter(for: "org")
-					}
-				}
-				.padding(.horizontal, 20)
-				
-				Spacer()
-			}
-		}
-        			.navigationTitle("Edit Recipients Rule".localized())
-		.navigationBarTitleDisplayMode(.large)
-		.navigationBarBackButtonHidden(true)
-		.toolbar {
-			ToolbarItem(placement: .navigationBarLeading) {
-                Button(action: {
-                    if viewModel.hasChanges {
-                        showDiscardConfirmation = true;
-                    } else {
-                        if let undoManager {
-                            viewModel.rollback(withUndoManager: undoManager);
-                        }
-                        dismiss();
-                    }
-                }) {
-                    HStack(alignment: .center, spacing: 4) {
-                        Image(systemName: "chevron.left")
-                    }
-                }.tint(.accent)
-            }
+			Color.softBackground
+				.ignoresSafeArea()
 
-			ToolbarItem(placement: .navigationBarTrailing) {
-                Button("Save".localized()) {
-                    viewModel.save(using: modelContext)
-					dismiss()
+			VStack(spacing: 0) {
+				RuleDetailTopBar(
+					title: "rule.detail.title.new".localized(),
+					onBack: handleBack,
+					onSave: saveAndDismiss
+				)
+				.padding(.horizontal, 22)
+				.padding(.top, 0)
+				.padding(.bottom, 8)
+
+				ScrollView {
+					VStack(alignment: .leading, spacing: 0) {
+						RuleNameCard(title: $viewModel.title, isFocused: $isTitleFocused)
+
+						Text("rule.detail.match.section".localized())
+							.font(.system(size: 13, weight: .semibold, design: .rounded))
+							.foregroundStyle(Color.softSecondaryText)
+							.padding(.top, 22)
+							.padding(.horizontal, 6)
+							.padding(.bottom, 14)
+
+						VStack(spacing: 12) {
+							RuleFilterCategoryCard(
+								title: "Job".localized(),
+								subtitle: detailSubtitle(viewModel.getJobFilterText()),
+								style: .job
+							) {
+								selectedFilter = viewModel.getOrCreateFilter(for: "job")
+							}
+
+							RuleFilterCategoryCard(
+								title: "Department".localized(),
+								subtitle: detailSubtitle(viewModel.getDepartmentFilterText()),
+								style: .department
+							) {
+								selectedFilter = viewModel.getOrCreateFilter(for: "dept")
+							}
+
+							RuleFilterCategoryCard(
+								title: "Organization".localized(),
+								subtitle: detailSubtitle(viewModel.getOrganizationFilterText()),
+								style: .organization(isAny: viewModel.getOrganizationFilterText() == "All".localized())
+							) {
+								selectedFilter = viewModel.getOrCreateFilter(for: "org")
+							}
+						}
+					}
+					.padding(.horizontal, 22)
+					.padding(.top, 6)
+					.padding(.bottom, 28)
 				}
-				.tint(.accent)
+				.scrollIndicators(.hidden)
 			}
 		}
+		.navigationTitle("")
+		.navigationBarTitleDisplayMode(.inline)
+		.navigationBarBackButtonHidden(true)
+		.toolbarVisibility(.hidden, for: .navigationBar)
 		.navigationDestination(item: $selectedFilter) { filter in
 //			let title: String
 //			switch filter.target {
@@ -130,43 +115,163 @@ struct RuleDetailScreen: View {
 			Button("Cancel".localized(), role: .cancel) {}
 		}
 	}
+
+	private func handleBack() {
+		if viewModel.hasChanges {
+			showDiscardConfirmation = true
+		} else {
+			if let undoManager {
+				viewModel.rollback(withUndoManager: undoManager)
+			}
+			dismiss()
+		}
+	}
+
+	private func saveAndDismiss() {
+		viewModel.save(using: modelContext)
+		dismiss()
+	}
+
+	private func detailSubtitle(_ value: String) -> String {
+		value == "All".localized() ? "Anyone".localized() : value
+	}
 }
 
-struct FilterRowView: View {
+private struct RuleDetailTopBar: View {
+	let title: String
+	let onBack: () -> Void
+	let onSave: () -> Void
+
+	var body: some View {
+		ZStack {
+			Text(title)
+				.font(.system(size: 16, weight: .bold, design: .rounded))
+				.foregroundStyle(Color.softPrimaryText)
+
+			HStack {
+				Button(action: onBack) {
+					Image(systemName: "chevron.left")
+						.font(.system(size: 16, weight: .bold))
+						.foregroundStyle(Color.softPrimaryText)
+						.frame(width: 36, height: 36)
+						.background(Color.softSurface, in: Circle())
+						.shadow(color: .black.opacity(0.06), radius: 6, x: 0, y: 2)
+				}
+				.accessibilityLabel("Back".localized())
+
+				Spacer()
+
+				Button("Save".localized(), action: onSave)
+					.font(.system(size: 15.5, weight: .bold, design: .rounded))
+					.foregroundStyle(Color.softAccent)
+			}
+		}
+		.frame(height: 36)
+	}
+}
+
+private struct RuleNameCard: View {
+	@Binding var title: String
+	let isFocused: FocusState<Bool>.Binding
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 8) {
+			Text("rule.detail.name.label".localized())
+				.font(.system(size: 12.5, weight: .semibold, design: .rounded))
+				.foregroundStyle(Color.softSecondaryText)
+
+			TextField("Enter rule title".localized(), text: $title)
+				.font(.system(size: 22, weight: .bold, design: .rounded))
+				.foregroundStyle(Color.softPrimaryText)
+				.tint(.softAccent)
+				.focused(isFocused)
+				.textInputAutocapitalization(.sentences)
+				.autocorrectionDisabled()
+		}
+		.padding(.horizontal, 20)
+		.padding(.vertical, 16)
+		.background(Color.softSurface, in: .rect(cornerRadius: 20, style: .continuous))
+		.shadow(color: Color.softAccent.opacity(0.07), radius: 18, x: 0, y: 6)
+	}
+}
+
+private struct RuleFilterCategoryCard: View {
 	let title: String
 	let subtitle: String
-	let icon: String
+	let style: RuleDetailCategoryStyle
 	let action: () -> Void
-	
+
 	var body: some View {
 		Button(action: action) {
-			HStack {
-				Image(systemName: icon)
-					.foregroundColor(.accent)
-					.frame(width: 24, height: 24)
-				
-				VStack(alignment: .leading, spacing: 4) {
-					Text(title)
-						.font(.headline)
-						.foregroundColor(.title)
-					
-					Text(subtitle)
-						.font(.subheadline)
-						.foregroundColor(.secondary)
+			HStack(spacing: 14) {
+				ZStack {
+					RoundedRectangle(cornerRadius: 15, style: .continuous)
+						.fill(style.background)
+
+					Image(systemName: style.symbolName)
+						.font(.system(size: 22, weight: .semibold))
+						.foregroundStyle(style.foreground)
 				}
-				
+				.frame(width: 44, height: 44)
+
+				VStack(alignment: .leading, spacing: 3) {
+					Text(title)
+						.font(.system(size: 16, weight: .bold, design: .rounded))
+						.foregroundStyle(Color.softPrimaryText)
+
+					Text(subtitle)
+						.font(.system(size: 12.5, weight: style.isNeutral ? .regular : .semibold, design: .rounded))
+						.foregroundStyle(style.subtitleColor)
+						.lineLimit(1)
+				}
+
 				Spacer()
-				
+
 				Image(systemName: "chevron.right")
-					.foregroundColor(.secondary)
-					.font(.caption)
+					.font(.system(size: 15, weight: .bold))
+					.foregroundStyle(Color.dynamic(light: "#CDC8D8", dark: "#6B6478"))
 			}
-			.padding()
-			.background(Color(.systemBackground))
-			.cornerRadius(12)
-			.shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
+			.padding(.horizontal, 18)
+			.padding(.vertical, 14)
+			.background(Color.softSurface, in: .rect(cornerRadius: 20, style: .continuous))
+			.shadow(color: Color.softAccent.opacity(0.07), radius: 18, x: 0, y: 6)
 		}
-		.buttonStyle(PlainButtonStyle())
+		.buttonStyle(.plain)
+		.accessibilityElement(children: .combine)
+	}
+}
+
+private struct RuleDetailCategoryStyle {
+	let symbolName: String
+	let background: Color
+	let foreground: Color
+	let subtitleColor: Color
+	let isNeutral: Bool
+
+	static let job = RuleDetailCategoryStyle(
+		symbolName: "briefcase",
+		background: .softJobTint,
+		foreground: .softAccent,
+		subtitleColor: .softAccent,
+		isNeutral: false
+	)
+
+	static let department = RuleDetailCategoryStyle(
+		symbolName: "building.2",
+		background: .softDepartmentTint,
+		foreground: .dynamic(light: "#E8895B", dark: "#E8A07B"),
+		subtitleColor: .dynamic(light: "#E8895B", dark: "#E8A07B"),
+		isNeutral: false
+	)
+
+	static func organization(isAny: Bool) -> RuleDetailCategoryStyle {
+		RuleDetailCategoryStyle(
+			symbolName: "building.2",
+			background: isAny ? .dynamic(light: "#F0EEF4", dark: "#302B3A") : .softOrganizationTint,
+			foreground: isAny ? .softSecondaryText : .dynamic(light: "#2BA55D", dark: "#5FCB8A"),
+			subtitleColor: isAny ? .dynamic(light: "#B3ACC0", dark: "#6B6478") : .dynamic(light: "#2BA55D", dark: "#5FCB8A"),
+			isNeutral: isAny
+		)
 	}
 }
 

--- a/design.md
+++ b/design.md
@@ -173,23 +173,104 @@ Current app file candidates:
 - `RuleDetailScreen.swift`
 - `RuleDetailScreenModel.swift`
 
+Source design reference:
+- `design/project/SendAdv Soft Friendly.dc.html`
+  - Light: `<!-- L2 Build filter -->`, around lines 84–124
+  - Dark: `<!-- D2 Build filter -->`, around lines 261–301
+
+Current mismatch notes:
+- The current `RuleDetailScreen` still uses the old plain layout:
+  - `Color.background` instead of `Color.softBackground`
+  - default large navigation title (`Edit Recipients Rule`) instead of the custom compact top bar
+  - `RoundedBorderTextFieldStyle` instead of a large rounded title card
+  - small system-style category rows instead of Soft Friendly cards
+  - generic icons/colors instead of category-specific icon tiles
+- This screen should be updated after the first-screen PR so the edit flow visually matches the refreshed list screen.
+
 Design requirements:
-- Use custom compact top bar instead of relying only on default navigation title.
-- Back button: circular surface button.
-- Center title: `New filter` or edit title.
-- Save action: primary accent text.
-- Name field is a rounded card:
+- Use `Color.softBackground` as the full-screen background.
+- Hide the default navigation title and build a custom top bar inside the screen.
+- Top bar layout:
+  - horizontal row with `padding(.horizontal, 22)` and compact vertical spacing below the status bar / safe area
+  - left: 36×36 circular surface back button
+    - light surface: white
+    - subtle shadow: `0 2 6 rgba(0,0,0,.06)`
+    - icon: `chevron.left`, primary text color
+  - center: title `New filter` for new filters, edit title/state equivalent for existing filters
+    - font: 16 pt, weight 700
+  - right: `Save`
+    - font: 15.5 pt, weight 700
+    - light accent `#5B5BD6`, dark accent `#9B8BF5`
+- Content layout:
+  - outer horizontal padding: 22 pt
+  - starts shortly below the top bar; prototype uses about 8 pt top padding
+- Name field card:
+  - white / dark card surface
+  - radius: 20 pt
+  - padding: horizontal 20 pt, vertical 18 pt
+  - soft card shadow: `0 6 18 rgba(91,91,214,.07)` in Light
   - label: `Give it a name`
-  - title value in large bold text
-- Filter categories shown as rounded cards:
-  - Job
-  - Department
-  - Organization
+    - font: 12.5 pt, weight 600
+    - secondary text color
+  - editable title value:
+    - font: 22 pt, weight 700
+    - top spacing: 8 pt
+    - active cursor/accent uses primary accent
+  - Implementation note: do not use `RoundedBorderTextFieldStyle`; use a plain `TextField` inside the card.
+- Section label between name card and category cards:
+  - text: `Who should match?`
+  - font: 13 pt, weight 600
+  - color: secondary text
+  - margin: top 26 pt, horizontal 6 pt, bottom 14 pt
+- Category cards:
+  - vertical stack spacing: 13 pt
+  - card background: white / dark card surface
+  - radius: 20 pt
+  - padding: horizontal 18 pt, vertical 16 pt
+  - soft card shadow matching the name card
+  - row layout: `HStack(spacing: 14)`
 - Each category card includes:
-  - colored icon tile
-  - category title
-  - current selection summary
-  - chevron
+  - 46×46 rounded icon tile, radius 15 pt
+  - category title: 16 pt, weight 700
+  - current selection summary: 12.5 pt, top spacing 3 pt
+  - trailing chevron: 18 pt icon, stroke/foreground `#cdc8d8` in Light
+- Category-specific visual treatment:
+  - Job:
+    - icon: briefcase
+    - tile bg: `#EEF0FF` light / `#272338` dark
+    - summary/accent fg: `#5B5BD6` light / `#9B8BF5` dark
+    - example summary: `Manager, Team Lead +1`
+  - Department:
+    - icon: building/house outline matching the prototype
+    - tile bg: `#FFF0E8` light / dark peach surface
+    - summary/accent fg: `#E8895B` light / `#E8A07B` dark
+    - example summary: `Sales`
+  - Organization:
+    - icon: office/building outline
+    - neutral tile bg when set to Any/Anyone: `#F0EEF4` light
+    - neutral fg: `#9B93A8` / muted dark equivalent
+    - example summary: `Anyone`
+- Preserve existing behavior:
+  - New filter is transient until Save.
+  - Back with unsaved changes shows the existing discard confirmation.
+  - Save inserts/updates via `RuleDetailScreenModel.save(using:)`.
+  - Tapping a category opens `RuleFilterScreen` with the existing filter model.
+
+Expected screen flow:
+
+```mermaid
+flowchart TD
+  A[Contact Filter List] --> B[Open RuleDetailScreen]
+  B --> C[Custom top bar: Back / New filter / Save]
+  C --> D[Name card: Give it a name]
+  D --> E[Who should match?]
+  E --> F[Job card]
+  E --> G[Department card]
+  E --> H[Organization card]
+  F --> I[RuleFilterScreen]
+  G --> I
+  H --> I
+```
 
 ### 3. Sub-filter Item Picker
 


### PR DESCRIPTION
## Goal and success criteria
- Refresh the Rule Detail screen to match the Soft Friendly design direction.
- Preserve existing behavior: transient new rules, Save, unsaved-change confirmation, and category navigation.
- Update design.md with the corrected Rule Detail source/design notes.

## What changed
- Rebuilt `RuleDetailScreen` with a custom Soft Friendly top bar.
- Replaced the old rounded-border text field with a `Give it a name` card.
- Added Soft Friendly category cards for Job, Department, and Organization.
- Applied category-specific icon tiles and accent colors.
- Added EN/KO strings for the new screen labels.
- Expanded `design.md` with the source reference and exact Rule Detail specs.

## User flow

```mermaid
flowchart TD
  A[Contact Filter List] --> B[Open Rule Detail]
  B --> C[Edit name in card]
  B --> D[Choose Job / Department / Organization]
  D --> E[RuleFilterScreen]
  B --> F{Tap Back with changes?}
  F -->|Yes| G[Show discard confirmation]
  B --> H[Tap Save]
  H --> I[Persist rule and dismiss]
```

## Verification
- [x] xcodebuild -workspace sendadv.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build 2>&1 | xcsift -f toon -w
- [x] mise x -- tuist build 2>&1 | xcsift -f toon -w
- [x] Manual visual check against supplied Rule Detail screenshot

## Notes
- This PR does not change SwiftData persistence logic.
- `RuleFilterScreen` still needs a separate Soft Friendly refresh.
- `design/` source bundle is intentionally not included.

## Rollback
- Revert this PR. No data migration is involved.

## Result
<img width="397" height="450" alt="스크린샷 2026-06-29 오후 10 26 39" src="https://github.com/user-attachments/assets/e9593e69-0528-4402-a669-59d4636d63ae" />
