### PR TITLE
feat: refresh rule filter design

### DIFF
--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -71,6 +71,28 @@
 "unsaved.changes.title" = "Save Changes?";
 "unsaved.changes.discard" = "Don't Save";
 
+// RuleFilterScreen
+"rule.filter.helper.job" = "Pick which job titles this filter includes";
+"rule.filter.helper.department" = "Pick which departments this filter includes";
+"rule.filter.helper.organization" = "Pick which organizations this filter includes";
+"rule.filter.helper.default" = "Pick which items this filter includes";
+"rule.filter.search.job" = "Search titles";
+"rule.filter.search.department" = "Search departments";
+"rule.filter.search.organization" = "Search organizations";
+"rule.filter.search.default" = "Search items";
+"rule.filter.selectAll.job" = "Select all titles";
+"rule.filter.selectAll.department" = "Select all departments";
+"rule.filter.selectAll.organization" = "Select all organizations";
+"rule.filter.selectAll.job.subtitle" = "Match everyone regardless of title";
+"rule.filter.selectAll.department.subtitle" = "Match everyone regardless of department";
+"rule.filter.selectAll.organization.subtitle" = "Match everyone regardless of organization";
+"rule.filter.selectAll.default.subtitle" = "Match everyone regardless of this filter";
+"rule.filter.count.job" = "%d titles";
+"rule.filter.count.department" = "%d departments";
+"rule.filter.count.organization" = "%d organizations";
+"rule.filter.count.default" = "%d items";
+"rule.filter.selected.count" = "%d selected";
+
 // Common actions
 "Back" = "Back";
 "Edit" = "Edit";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -60,6 +60,28 @@
 "unsaved.changes.title" = "변경사항을 저장하시겠습니까?";
 "unsaved.changes.discard" = "저장 안 함";
 
+// RuleFilterScreen
+"rule.filter.helper.job" = "이 필터에 포함할 직책을 선택하세요";
+"rule.filter.helper.department" = "이 필터에 포함할 부서를 선택하세요";
+"rule.filter.helper.organization" = "이 필터에 포함할 회사를 선택하세요";
+"rule.filter.helper.default" = "이 필터에 포함할 항목을 선택하세요";
+"rule.filter.search.job" = "직책 검색";
+"rule.filter.search.department" = "부서 검색";
+"rule.filter.search.organization" = "회사 검색";
+"rule.filter.search.default" = "항목 검색";
+"rule.filter.selectAll.job" = "모든 직책 선택";
+"rule.filter.selectAll.department" = "모든 부서 선택";
+"rule.filter.selectAll.organization" = "모든 회사 선택";
+"rule.filter.selectAll.job.subtitle" = "직책과 관계없이 모두 포함";
+"rule.filter.selectAll.department.subtitle" = "부서와 관계없이 모두 포함";
+"rule.filter.selectAll.organization.subtitle" = "회사와 관계없이 모두 포함";
+"rule.filter.selectAll.default.subtitle" = "이 필터와 관계없이 모두 포함";
+"rule.filter.count.job" = "%d개 직책";
+"rule.filter.count.department" = "%d개 부서";
+"rule.filter.count.organization" = "%d개 회사";
+"rule.filter.count.default" = "%d개 항목";
+"rule.filter.selected.count" = "%d개 선택됨";
+
 // Common actions
 "Back" = "뒤로";
 "Edit" = "편집";

--- a/Projects/App/Sources/Screens/RuleFilterScreen.swift
+++ b/Projects/App/Sources/Screens/RuleFilterScreen.swift
@@ -26,16 +26,6 @@ struct RuleFilterScreen: View {
 				.ignoresSafeArea()
 
 			VStack(spacing: 0) {
-				RuleFilterTopBar(
-					title: viewModel.title,
-					style: style,
-					onBack: { dismiss() },
-					onDone: saveAndDismiss
-				)
-				.padding(.horizontal, 22)
-				.padding(.top, 0)
-				.padding(.bottom, 10)
-
 				ScrollView {
 					VStack(alignment: .leading, spacing: 0) {
 						Text(helperText(for: viewModel.target))
@@ -91,10 +81,32 @@ struct RuleFilterScreen: View {
 				.scrollIndicators(.hidden)
 			}
 		}
-		.navigationTitle("")
 		.navigationBarTitleDisplayMode(.inline)
-		.navigationBarBackButtonHidden(true)
-		.toolbarVisibility(.hidden, for: .navigationBar)
+		.toolbar {
+			ToolbarItem(placement: .title) {
+				HStack(spacing: 8) {
+					ZStack {
+						RoundedRectangle(cornerRadius: 7, style: .continuous)
+							.fill(style.iconBackground)
+
+						Image(systemName: style.symbolName)
+							.font(.system(size: 13, weight: .semibold))
+							.foregroundStyle(style.accent)
+					}
+					.frame(width: 22, height: 22)
+
+					Text(viewModel.title)
+						.font(.system(size: 16, weight: .bold, design: .rounded))
+						.foregroundStyle(Color.softPrimaryText)
+				}
+			}
+
+			ToolbarItem(placement: .topBarTrailing) {
+				Button("Done".localized(), action: saveAndDismiss)
+					.font(.system(size: 15.5, weight: .bold, design: .rounded))
+					.foregroundStyle(style.accent)
+			}
+		}
 		.onAppear {
 			viewModel.loadItems()
 		}
@@ -168,52 +180,6 @@ struct RuleFilterScreen: View {
 		case .none:
 			return String(format: "rule.filter.count.default".localized(), count)
 		}
-	}
-}
-
-private struct RuleFilterTopBar: View {
-	let title: String
-	let style: RuleFilterCategoryStyle
-	let onBack: () -> Void
-	let onDone: () -> Void
-
-	var body: some View {
-		ZStack {
-			HStack(spacing: 8) {
-				ZStack {
-					RoundedRectangle(cornerRadius: 7, style: .continuous)
-						.fill(style.iconBackground)
-
-					Image(systemName: style.symbolName)
-						.font(.system(size: 13, weight: .semibold))
-						.foregroundStyle(style.accent)
-				}
-				.frame(width: 22, height: 22)
-
-				Text(title)
-					.font(.system(size: 16, weight: .bold, design: .rounded))
-					.foregroundStyle(Color.softPrimaryText)
-			}
-
-			HStack {
-				Button(action: onBack) {
-					Image(systemName: "chevron.left")
-						.font(.system(size: 16, weight: .bold))
-						.foregroundStyle(Color.softPrimaryText)
-						.frame(width: 36, height: 36)
-						.background(Color.softSurface, in: Circle())
-						.shadow(color: .black.opacity(0.06), radius: 6, x: 0, y: 2)
-				}
-				.accessibilityLabel("Back".localized())
-
-				Spacer()
-
-				Button("Done".localized(), action: onDone)
-					.font(.system(size: 15.5, weight: .bold, design: .rounded))
-					.foregroundStyle(style.accent)
-			}
-		}
-		.frame(height: 36)
 	}
 }
 

--- a/Projects/App/Sources/Screens/RuleFilterScreen.swift
+++ b/Projects/App/Sources/Screens/RuleFilterScreen.swift
@@ -8,80 +8,397 @@ import SwiftUI
 import SwiftData
 
 struct RuleFilterScreen: View {
-    @Environment(\.dismiss) private var dismiss
-    @Environment(\.modelContext) private var modelContext
-    
-    @State private var viewModel: RuleFilterScreenModel
-    
-    init(filter: RecipientsFilter) {
-        _viewModel = State(initialValue: RuleFilterScreenModel(filter: filter))
-    }
-    
-    var body: some View {
-        List {
-            // All items toggle
-            Toggle(isOn: Binding(
-                get: { viewModel.selectAll },
-                set: { newValue in
-                    viewModel.toggleSelectAll(newValue)
-                }
-            )) {
-                Text("Select All".localized())
-                    .font(.headline)
-            }
-            .padding(.vertical, 8)
-            
-            // Filter items list
-            ForEach(viewModel.availableItems, id: \.self) { item in
-                HStack {
-                    Text(item)
-                        .foregroundColor(.primary)
-                    Spacer()
-                    if viewModel.selectedItems.contains(item) {
-                        Image(systemName: "checkmark")
-                            .foregroundColor(.accentColor)
-                    }
-                }
-                .contentShape(Rectangle())
-                .onTapGesture {
-                    viewModel.toggleItem(item)
-                }
-            }
-        }
-        .listStyle(PlainListStyle())
-        .navigationTitle(viewModel.title)
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button("Done".localized()) {
-                    viewModel.save(context: modelContext)
-                    dismiss()
-                }
-                .tint(.accent)
-            }
-        }
-        .onAppear {
-            viewModel.loadItems()
-        }
-        .onDisappear {
-            //
-        }
-    }
+	@Environment(\.dismiss) private var dismiss
+	@Environment(\.modelContext) private var modelContext
+
+	@State private var viewModel: RuleFilterScreenModel
+	@FocusState private var isSearchFocused: Bool
+
+	init(filter: RecipientsFilter) {
+		_viewModel = State(initialValue: RuleFilterScreenModel(filter: filter))
+	}
+
+	var body: some View {
+		let style = RuleFilterCategoryStyle(target: viewModel.target)
+
+		ZStack {
+			Color.softBackground
+				.ignoresSafeArea()
+
+			VStack(spacing: 0) {
+				RuleFilterTopBar(
+					title: viewModel.title,
+					style: style,
+					onBack: { dismiss() },
+					onDone: saveAndDismiss
+				)
+				.padding(.horizontal, 22)
+				.padding(.top, 0)
+				.padding(.bottom, 10)
+
+				ScrollView {
+					VStack(alignment: .leading, spacing: 0) {
+						Text(helperText(for: viewModel.target))
+							.font(.system(size: 13, weight: .regular, design: .rounded))
+							.foregroundStyle(Color.softSecondaryText)
+							.padding(.horizontal, 2)
+							.padding(.bottom, 12)
+
+						RuleFilterSearchField(
+							text: $viewModel.searchText,
+							placeholder: searchPlaceholder(for: viewModel.target),
+							isFocused: $isSearchFocused
+						)
+
+						RuleFilterSelectAllCard(
+							title: selectAllTitle(for: viewModel.target),
+							subtitle: selectAllSubtitle(for: viewModel.target),
+							isOn: Binding(
+								get: { viewModel.selectAll },
+								set: { viewModel.toggleSelectAll($0) }
+							)
+						)
+						.padding(.top, 14)
+
+						HStack {
+							Text(itemCountText(for: viewModel.target, count: viewModel.availableItems.count))
+								.font(.system(size: 12, weight: .semibold, design: .rounded))
+								.textCase(.uppercase)
+								.tracking(0.4)
+								.foregroundStyle(Color.softSecondaryText)
+
+							Spacer()
+
+							Text(String(format: "rule.filter.selected.count".localized(), viewModel.selectedCount))
+								.font(.system(size: 12.5, weight: .bold, design: .rounded))
+								.foregroundStyle(style.accent)
+						}
+						.padding(.horizontal, 4)
+						.padding(.top, 20)
+						.padding(.bottom, 10)
+
+						RuleFilterItemsPanel(
+							items: viewModel.filteredItems,
+							selectedItems: viewModel.selectedItems,
+							style: style,
+							onToggle: { item in viewModel.toggleItem(item) }
+						)
+					}
+					.padding(.horizontal, 22)
+					.padding(.top, 6)
+					.padding(.bottom, 28)
+				}
+				.scrollIndicators(.hidden)
+			}
+		}
+		.navigationTitle("")
+		.navigationBarTitleDisplayMode(.inline)
+		.navigationBarBackButtonHidden(true)
+		.toolbarVisibility(.hidden, for: .navigationBar)
+		.onAppear {
+			viewModel.loadItems()
+		}
+	}
+
+	private func saveAndDismiss() {
+		viewModel.save(context: modelContext)
+		dismiss()
+	}
+
+	private func helperText(for target: FilterTarget?) -> String {
+		switch target {
+		case .job:
+			return "rule.filter.helper.job".localized()
+		case .department:
+			return "rule.filter.helper.department".localized()
+		case .organization:
+			return "rule.filter.helper.organization".localized()
+		case .none:
+			return "rule.filter.helper.default".localized()
+		}
+	}
+
+	private func searchPlaceholder(for target: FilterTarget?) -> String {
+		switch target {
+		case .job:
+			return "rule.filter.search.job".localized()
+		case .department:
+			return "rule.filter.search.department".localized()
+		case .organization:
+			return "rule.filter.search.organization".localized()
+		case .none:
+			return "rule.filter.search.default".localized()
+		}
+	}
+
+	private func selectAllTitle(for target: FilterTarget?) -> String {
+		switch target {
+		case .job:
+			return "rule.filter.selectAll.job".localized()
+		case .department:
+			return "rule.filter.selectAll.department".localized()
+		case .organization:
+			return "rule.filter.selectAll.organization".localized()
+		case .none:
+			return "Select All".localized()
+		}
+	}
+
+	private func selectAllSubtitle(for target: FilterTarget?) -> String {
+		switch target {
+		case .job:
+			return "rule.filter.selectAll.job.subtitle".localized()
+		case .department:
+			return "rule.filter.selectAll.department.subtitle".localized()
+		case .organization:
+			return "rule.filter.selectAll.organization.subtitle".localized()
+		case .none:
+			return "rule.filter.selectAll.default.subtitle".localized()
+		}
+	}
+
+	private func itemCountText(for target: FilterTarget?, count: Int) -> String {
+		switch target {
+		case .job:
+			return String(format: "rule.filter.count.job".localized(), count)
+		case .department:
+			return String(format: "rule.filter.count.department".localized(), count)
+		case .organization:
+			return String(format: "rule.filter.count.organization".localized(), count)
+		case .none:
+			return String(format: "rule.filter.count.default".localized(), count)
+		}
+	}
 }
 
+private struct RuleFilterTopBar: View {
+	let title: String
+	let style: RuleFilterCategoryStyle
+	let onBack: () -> Void
+	let onDone: () -> Void
 
+	var body: some View {
+		ZStack {
+			HStack(spacing: 8) {
+				ZStack {
+					RoundedRectangle(cornerRadius: 7, style: .continuous)
+						.fill(style.iconBackground)
+
+					Image(systemName: style.symbolName)
+						.font(.system(size: 13, weight: .semibold))
+						.foregroundStyle(style.accent)
+				}
+				.frame(width: 22, height: 22)
+
+				Text(title)
+					.font(.system(size: 16, weight: .bold, design: .rounded))
+					.foregroundStyle(Color.softPrimaryText)
+			}
+
+			HStack {
+				Button(action: onBack) {
+					Image(systemName: "chevron.left")
+						.font(.system(size: 16, weight: .bold))
+						.foregroundStyle(Color.softPrimaryText)
+						.frame(width: 36, height: 36)
+						.background(Color.softSurface, in: Circle())
+						.shadow(color: .black.opacity(0.06), radius: 6, x: 0, y: 2)
+				}
+				.accessibilityLabel("Back".localized())
+
+				Spacer()
+
+				Button("Done".localized(), action: onDone)
+					.font(.system(size: 15.5, weight: .bold, design: .rounded))
+					.foregroundStyle(style.accent)
+			}
+		}
+		.frame(height: 36)
+	}
+}
+
+private struct RuleFilterSearchField: View {
+	@Binding var text: String
+	let placeholder: String
+	let isFocused: FocusState<Bool>.Binding
+
+	var body: some View {
+		HStack(spacing: 9) {
+			Image(systemName: "magnifyingglass")
+				.font(.system(size: 17, weight: .semibold))
+				.foregroundStyle(Color.dynamic(light: "#B3ACC0", dark: "#6B6478"))
+
+			TextField(placeholder, text: $text)
+				.font(.system(size: 15, weight: .regular, design: .rounded))
+				.foregroundStyle(Color.softPrimaryText)
+				.tint(.softAccent)
+				.focused(isFocused)
+				.textInputAutocapitalization(.never)
+				.autocorrectionDisabled()
+		}
+		.padding(.horizontal, 14)
+		.padding(.vertical, 11)
+		.background(Color.softSurface, in: .rect(cornerRadius: 14, style: .continuous))
+		.shadow(color: Color.softAccent.opacity(0.06), radius: 14, x: 0, y: 4)
+	}
+}
+
+private struct RuleFilterSelectAllCard: View {
+	let title: String
+	let subtitle: String
+	@Binding var isOn: Bool
+
+	var body: some View {
+		HStack(spacing: 13) {
+			VStack(alignment: .leading, spacing: 2) {
+				Text(title)
+					.font(.system(size: 15.5, weight: .bold, design: .rounded))
+					.foregroundStyle(Color.softPrimaryText)
+
+				Text(subtitle)
+					.font(.system(size: 12, weight: .regular, design: .rounded))
+					.foregroundStyle(Color.softSecondaryText)
+			}
+
+			Spacer()
+
+			Toggle("", isOn: $isOn)
+				.labelsHidden()
+				.tint(.softAccent)
+		}
+		.padding(.horizontal, 18)
+		.padding(.vertical, 15)
+		.background(Color.softSurface, in: .rect(cornerRadius: 16, style: .continuous))
+		.shadow(color: Color.softAccent.opacity(0.07), radius: 18, x: 0, y: 6)
+	}
+}
+
+private struct RuleFilterItemsPanel: View {
+	let items: [String]
+	let selectedItems: Set<String>
+	let style: RuleFilterCategoryStyle
+	let onToggle: (String) -> Void
+
+	var body: some View {
+		VStack(spacing: 0) {
+			ForEach(items, id: \.self) { item in
+				let isSelected = selectedItems.contains(item)
+
+				Button {
+					onToggle(item)
+				} label: {
+					HStack(spacing: 12) {
+						Text(item)
+							.font(.system(size: 15.5, weight: isSelected ? .semibold : .regular, design: .rounded))
+							.foregroundStyle(Color.softPrimaryText)
+
+						Spacer()
+
+						SelectionIndicator(isSelected: isSelected, accent: style.accent)
+					}
+					.padding(.horizontal, 18)
+					.padding(.vertical, 14)
+					.background(isSelected ? style.selectedBackground : Color.softSurface)
+				}
+				.buttonStyle(.plain)
+
+				if item != items.last {
+					Divider()
+						.background(Color.softDivider)
+				}
+			}
+		}
+		.background(Color.softSurface, in: .rect(cornerRadius: 18, style: .continuous))
+		.clipShape(.rect(cornerRadius: 18, style: .continuous))
+		.shadow(color: Color.softAccent.opacity(0.07), radius: 18, x: 0, y: 6)
+	}
+}
+
+private struct SelectionIndicator: View {
+	let isSelected: Bool
+	let accent: Color
+
+	var body: some View {
+		ZStack {
+			Circle()
+				.fill(isSelected ? accent : .clear)
+				.overlay {
+					Circle()
+						.stroke(isSelected ? accent : Color.dynamic(light: "#E0DBE8", dark: "#3D3850"), lineWidth: 2)
+				}
+
+			if isSelected {
+				Image(systemName: "checkmark")
+					.font(.system(size: 11, weight: .bold))
+					.foregroundStyle(.white)
+			}
+		}
+		.frame(width: 24, height: 24)
+	}
+}
+
+private struct RuleFilterCategoryStyle {
+	let symbolName: String
+	let iconBackground: Color
+	let accent: Color
+	let selectedBackground: Color
+
+	init(target: FilterTarget?) {
+		self = Self.style(for: target)
+	}
+
+	private init(symbolName: String, iconBackground: Color, accent: Color, selectedBackground: Color) {
+		self.symbolName = symbolName
+		self.iconBackground = iconBackground
+		self.accent = accent
+		self.selectedBackground = selectedBackground
+	}
+
+	private static func style(for target: FilterTarget?) -> RuleFilterCategoryStyle {
+		switch target {
+		case .job:
+			return RuleFilterCategoryStyle(
+				symbolName: "briefcase",
+				iconBackground: .softJobTint,
+				accent: .softAccent,
+				selectedBackground: .dynamic(light: "#F6F5FF", dark: "#272239")
+			)
+		case .department:
+			return RuleFilterCategoryStyle(
+				symbolName: "building.2",
+				iconBackground: .softDepartmentTint,
+				accent: .dynamic(light: "#E8895B", dark: "#E8A07B"),
+				selectedBackground: .dynamic(light: "#FFF6F0", dark: "#33241F")
+			)
+		case .organization:
+			return RuleFilterCategoryStyle(
+				symbolName: "building",
+				iconBackground: .softOrganizationTint,
+				accent: .dynamic(light: "#2BA55D", dark: "#5FCB8A"),
+				selectedBackground: .dynamic(light: "#F1FBF5", dark: "#1E2D26")
+			)
+		case .none:
+			return RuleFilterCategoryStyle(
+				symbolName: "line.3.horizontal.decrease.circle",
+				iconBackground: .dynamic(light: "#F0EEF4", dark: "#302B3A"),
+				accent: .softAccent,
+				selectedBackground: .dynamic(light: "#F6F5FF", dark: "#272239")
+			)
+		}
+	}
+}
 
 #Preview {
-    let config = ModelConfiguration(isStoredInMemoryOnly: true)
-    let container = try! ModelContainer(for: RecipientsFilter.self, configurations: config)
-    
-    let filter = RecipientsFilter(target: .job, includes: nil, excludes: nil, all: true)
-    container.mainContext.insert(filter)
+	let config = ModelConfiguration(isStoredInMemoryOnly: true)
+	let container = try! ModelContainer(for: RecipientsFilter.self, configurations: config)
 
-    return NavigationStack {
-        RuleFilterScreen(
-            filter: filter
-        )
-    }
-    .modelContainer(container)
+	let filter = RecipientsFilter(target: .job, includes: nil, excludes: nil, all: true)
+	container.mainContext.insert(filter)
+
+	return NavigationStack {
+		RuleFilterScreen(
+			filter: filter
+		)
+	}
+	.modelContainer(container)
 }

--- a/Projects/App/Sources/ViewModels/RuleFilterScreenModel.swift
+++ b/Projects/App/Sources/ViewModels/RuleFilterScreenModel.swift
@@ -12,12 +12,30 @@ class RuleFilterScreenModel {
     var selectAll: Bool = false
     var availableItems: [String] = []
     var selectedItems: Set<String> = []
+    var searchText: String = ""
     
     private(set) var filter: RecipientsFilter
     private(set) var isSaved = false
     
     var title: String {
         FilterTarget(rawValue: filter.target ?? "")?.displayName.localized() ?? ""
+    }
+
+    var target: FilterTarget? {
+        FilterTarget(rawValue: filter.target ?? "")
+    }
+
+    var filteredItems: [String] {
+        let trimmedSearchText = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedSearchText.isEmpty else { return availableItems }
+
+        return availableItems.filter { item in
+            item.localizedCaseInsensitiveContains(trimmedSearchText)
+        }
+    }
+
+    var selectedCount: Int {
+        selectedItems.count
     }
     
     init(filter: RecipientsFilter) {

--- a/design.md
+++ b/design.md
@@ -278,30 +278,75 @@ Current app file candidates:
 - `RuleFilterScreen.swift`
 - `RuleFilterScreenModel.swift`
 
+Source design reference:
+- `design/project/SendAdv Soft Friendly.dc.html`
+  - Light: `<!-- L3 Sub-filter detail (NEW) -->`, around lines 126–169
+  - Dark: `<!-- D3 Sub-filter detail -->`, around lines 303–343
+
+Current mismatch notes:
+- The current `RuleFilterScreen` is still a plain `List` with a default navigation title.
+- It is missing the custom top bar, category icon in the title, helper copy, search field, select-all explanatory card, count summary row, and rounded grouped item panel.
+- The visual selection state should use filled circular checkmarks and selected-row backgrounds, not a trailing plain checkmark.
+
 Design requirements:
-- Top bar includes:
-  - circular back button
-  - category icon + category title
-  - Done action
+- Use `Color.softBackground` as the full-screen background.
+- Hide the default navigation bar and build a custom top bar inside the screen.
+- Top bar layout:
+  - horizontal row with outer padding 22 pt
+  - left: 36×36 circular surface back button
+  - center: category title with a compact icon tile
+    - icon tile: 22×22, radius 7 pt
+    - title: 16 pt, weight 700
+  - right: `Done`, 15.5 pt, weight 700, category accent color
 - Helper copy:
   - `Pick which job titles this filter includes`
   - Adapt wording by category.
 - Add search field:
-  - Rounded surface
-  - Search icon
+  - white / dark rounded surface
+  - radius: 14 pt
+  - padding: horizontal 14 pt, vertical 11 pt
+  - search icon, 17 pt
   - Placeholder changes by category, e.g. `Search titles`
 - Select all row:
   - title: `Select all titles`
   - subtitle: `Match everyone regardless of title`
-  - toggle
+  - toggle on the trailing side
+  - card radius: 16 pt
+  - padding: horizontal 18 pt, vertical 15 pt
 - Section summary row:
   - left: item count, e.g. `7 titles`
   - right: selected count, e.g. `3 selected`
+  - margin: top 20 pt, horizontal 4 pt, bottom 10 pt
 - Item list:
   - rounded grouped panel
+  - panel radius: 18 pt
   - selected rows use subtle accent background
   - selected indicator is filled circle with checkmark
   - unselected indicator is outlined circle
+  - row padding: horizontal 18 pt, vertical 14 pt
+  - row title: 15.5 pt
+  - selected row title weight: 600
+  - divider color: `#F3F0F6` light / `#2C2839` dark
+- Preserve existing behavior:
+  - Back dismisses without saving pending changes.
+  - Done calls `RuleFilterScreenModel.save(context:)` then dismisses.
+  - Select All keeps the existing select-all semantics.
+  - Tapping an item toggles only the local ViewModel state until Done.
+
+Expected screen flow:
+
+```mermaid
+flowchart TD
+  A[RuleDetailScreen category card] --> B[RuleFilterScreen]
+  B --> C[Search available items]
+  B --> D[Toggle Select All]
+  B --> E[Toggle individual item]
+  D --> F[Update selected count]
+  E --> F
+  B --> G{Tap Done?}
+  G -->|Yes| H[Save filter includes/all and dismiss]
+  G -->|Back| I[Dismiss without saving]
+```
 
 ### 4. Send Confirmation / Messages Handoff
 


### PR DESCRIPTION
## Goal and success criteria
- Refresh the Rule Filter item picker screen to match the Soft Friendly design direction.
- Preserve existing behavior: local selection state, Select All semantics, Done save, and back dismiss.
- Update design.md with the corrected Sub-filter Item Picker source/design notes.

## What changed
- Rebuilt `RuleFilterScreen` with a custom Soft Friendly top bar.
- Added category icon/title treatment and category-colored Done action.
- Added helper copy, custom search field, Select All card, count summary, and rounded grouped item panel.
- Added selected row background with filled check indicator and outlined unselected indicator.
- Added search support to `RuleFilterScreenModel` via `searchText` and `filteredItems`.
- Added EN/KO strings for helper/search/select-all/count labels.
- Expanded `design.md` with the source reference and exact RuleFilter specs.

## User flow

```mermaid
flowchart TD
  A[Rule Detail category card] --> B[Open Rule Filter screen]
  B --> C[Search items]
  B --> D[Toggle Select All]
  B --> E[Toggle individual rows]
  C --> F[Filtered rounded item panel]
  D --> G[Selected count updates]
  E --> G
  B --> H[Tap Done]
  H --> I[Save filter and dismiss]
```

## Verification
- [x] xcodebuild -workspace sendadv.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build 2>&1 | xcsift -f toon -w
- [x] mise x -- tuist build 2>&1 | xcsift -f toon -w
- [x] Manual visual check against supplied Rule Filter screenshot

## Notes
- This keeps a custom search field instead of `.searchable` to match the prototype's in-content rounded search card.
- `design/` source bundle is intentionally not included.

## Rollback
- Revert this PR. No data migration is involved.


## Result
<img width="399" height="191" alt="스크린샷 2026-06-30 오전 9 10 26" src="https://github.com/user-attachments/assets/d1071510-35ea-4583-a573-4c1cafbdab0c" />
