### PR TITLE
refactor: use navigation bar for rule list

### DIFF
--- a/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
@@ -116,7 +116,7 @@ struct RecipientRuleListScreen: View {
 
 			ScrollView {
 				LazyVStack(spacing: 12) {
-					RuleListHeaderView(enabledCount: enabledRuleCount)
+					RuleListStatusView(enabledCount: enabledRuleCount)
 						.padding(.bottom, 0)
 
 					ForEach(rules) { rule in
@@ -140,7 +140,7 @@ struct RecipientRuleListScreen: View {
 							.padding(.top, 58)
 					}
 				}
-				.padding(.top, 0)
+				.padding(.top, 12)
 				.padding(.horizontal, 30)
 				.padding(.bottom, 146)
 			}
@@ -190,11 +190,10 @@ struct RecipientRuleListScreen: View {
 				.transition(.opacity.combined(with: .move(edge: .bottom)))
 			}
 		}
-		.navigationTitle("")
-		.toolbarVisibility(.hidden, for: .navigationBar)
-		.navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+		.navigationTitle("rules.header.title".localized())
+		.navigationBarTitleDisplayMode(.large)
+		.toolbar {
+			ToolbarItem(placement: .topBarTrailing) {
 				Button {
 					if isAddFirstFilterTipVisible {
 						addFirstFilterTip.logActionTaken()
@@ -486,20 +485,13 @@ struct RecipientRuleListScreen: View {
 }
 
 
-private struct RuleListHeaderView: View {
+private struct RuleListStatusView: View {
 	let enabledCount: Int
 
 	var body: some View {
-		VStack(alignment: .leading, spacing: 8) {
-			Text("rules.header.title".localized())
-				.font(.system(size: 40, weight: .bold, design: .rounded))
-				.foregroundStyle(Color.softPrimaryText)
-				.tracking(-1.2)
-
-			Text(String(format: "rules.header.summary".localized(), enabledCount))
-				.font(.title3.weight(.bold))
-				.foregroundStyle(Color.softSecondaryText)
-		}
+		Text(String(format: "rules.header.summary".localized(), enabledCount))
+			.font(.title3.weight(.bold))
+			.foregroundStyle(Color.softSecondaryText)
 		.frame(maxWidth: .infinity, alignment: .leading)
 	}
 }


### PR DESCRIPTION
## Goal and success criteria
- Migrate the Filter List title/action from a custom in-content top header to the system Navigation Bar.
- Preserve the Soft Friendly status copy, filter cards, Native Ad placement, and bottom CTA behavior.

## What changed
- Restored `navigationTitle` with large display mode for the filter list title.
- Kept the add button in `.topBarTrailing` toolbar placement.
- Removed the custom in-content title from `RuleListHeaderView`.
- Renamed the remaining header helper to `RuleListStatusView` for the enabled-filter status line.
- Adjusted content top padding to sit naturally below the large navigation title.

## User flow

```mermaid
flowchart TD
  A[Open Filter List] --> B[System Navigation Bar title]
  B --> C[Toolbar add button]
  A --> D[Status line and filter cards]
  D --> E[Existing send flow]
```

## Verification
- [x] xcodebuild -workspace sendadv.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build 2>&1 | xcsift -f toon -w

## Notes
- No persistence or send-flow behavior changed.
- `design/` source bundle is intentionally not included.

## Rollback
- Revert this PR. No data migration is involved.
