### PR TITLE
feat: add rule list edit delete mode

### DIFF
--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -60,6 +60,8 @@
 "rules.add" = "Add New Filter";
 "rules.header.title" = "Your filters";
 "rules.header.summary" = "%d turned on · ready to reach people";
+"rule.delete.confirmation.title" = "Delete this filter?";
+"rule.delete.confirmation.message" = "This contact filter will be removed.";
 
 // RuleDetailScreen
 "Rule Title" = "Filter Title";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -49,6 +49,8 @@
 "rules.add" = "새 필터 추가";
 "rules.header.title" = "내 필터";
 "rules.header.summary" = "%d개 켜짐 · 바로 전송 준비됨";
+"rule.delete.confirmation.title" = "이 필터를 삭제할까요?";
+"rule.delete.confirmation.message" = "이 연락처 필터가 삭제됩니다.";
 
 // RuleDetailScreen
 "Rule Title" = "필터 이름";

--- a/Projects/App/Sources/Screens/RecipientList/RecipientListRowView.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientListRowView.swift
@@ -10,7 +10,9 @@ import SwiftData
 
 struct RecipientRuleRowView: View {
 	let rule: RecipientsRule
+	let isEditing: Bool
 	let onToggle: (Bool) -> Void
+	let onDelete: () -> Void
 
 	var isTitleEmpty: Bool {
 		return rule.title?.isEmpty ?? true;
@@ -81,19 +83,29 @@ struct RecipientRuleRowView: View {
 
 			Spacer(minLength: 8)
 
-			Toggle("", isOn: Binding(
-				get: { rule.enabled },
-				set: { onToggle($0) }
-		))
-		.labelsHidden()
-		.tint(.softAccent)
-		.scaleEffect(1.12)
+			if isEditing {
+				Button(role: .destructive, action: onDelete) {
+					Image(systemName: "minus.circle.fill")
+						.font(.system(size: 30, weight: .semibold))
+						.foregroundStyle(.red)
+				}
+				.buttonStyle(.plain)
+				.accessibilityLabel("Delete".localized())
+			} else {
+				Toggle("", isOn: Binding(
+					get: { rule.enabled },
+					set: { onToggle($0) }
+				))
+				.labelsHidden()
+				.tint(.softAccent)
+				.scaleEffect(1.12)
+			}
 		}
 		.padding(.leading, 24)
 		.padding(.trailing, 20)
 		.padding(.vertical, 18)
 		.softFriendlyCard()
-		.opacity(rule.enabled ? 1 : 0.72)
+		.opacity(rule.enabled || isEditing ? 1 : 0.72)
 		.accessibilityElement(children: .combine)
 	}
 }
@@ -117,7 +129,7 @@ struct RecipientRuleRowView_Previews: PreviewProvider {
 		let rule = RecipientsRule(title: "회사 동료들", enabled: true)
 		container.mainContext.insert(rule)
 
-		return RecipientRuleRowView(rule: rule) { isOn in }
+		return RecipientRuleRowView(rule: rule, isEditing: false, onToggle: { isOn in }, onDelete: {})
 			.previewLayout(.sizeThatFits)
 			.modelContainer(container)
 	}

--- a/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
@@ -76,6 +76,9 @@ struct RecipientRuleListScreen: View {
 	@State private var batchProgressText: String = ""
 	@State private var isAdFree: Bool = LSDefaults.isAdFree
 	@State private var showAdFreeToast = false
+	@State private var isEditingRules = false
+	@State private var rulePendingDeletion: RecipientsRule?
+	@State private var showingDeleteRuleConfirmation = false
 	    private let batchSize: Int = 20
 	    private let addFirstFilterTip = AddFirstFilterTip()
 	    @State private var isAddFirstFilterTipVisible = false
@@ -120,17 +123,27 @@ struct RecipientRuleListScreen: View {
 						.padding(.bottom, 0)
 
 					ForEach(rules) { rule in
-						RecipientRuleRowView(rule: rule) { isEnabled in
-							toggleRule(rule, isEnabled: isEnabled)
-						}
+						RecipientRuleRowView(
+							rule: rule,
+							isEditing: isEditingRules,
+							onToggle: { isEnabled in
+								toggleRule(rule, isEnabled: isEnabled)
+							},
+							onDelete: {
+								requestDeleteRule(rule)
+							}
+						)
 						.onTapGesture {
+							guard !isEditingRules else { return }
 							state = .editingRule(rule)
 						}
 						.contextMenu {
-							Button(role: .destructive) {
-								deleteRule(rule)
-							} label: {
-								Label("Delete".localized(), systemImage: "trash")
+							if !isEditingRules {
+								Button(role: .destructive) {
+									requestDeleteRule(rule)
+								} label: {
+									Label("Delete".localized(), systemImage: "trash")
+								}
 							}
 						}
 					}
@@ -154,7 +167,7 @@ struct RecipientRuleListScreen: View {
 			}
 
 			// 전송 버튼
-			if !rules.isEmpty {
+			if !rules.isEmpty && !isEditingRules {
 				VStack {
 					Spacer()
 					HStack(alignment: .center, spacing: 14) {
@@ -193,39 +206,63 @@ struct RecipientRuleListScreen: View {
 		.navigationTitle("rules.header.title".localized())
 		.navigationBarTitleDisplayMode(.large)
 		.toolbar {
-			ToolbarItem(placement: .topBarTrailing) {
-				Button {
-					if isAddFirstFilterTipVisible {
-						addFirstFilterTip.logActionTaken()
+			ToolbarItem(placement: .topBarLeading) {
+				if !rules.isEmpty {
+					Button {
+						withAnimation(.easeInOut(duration: 0.2)) {
+							isEditingRules.toggle()
+						}
+					} label: {
+						if isEditingRules {
+							Image(systemName: "checkmark")
+						} else {
+							Text("Edit".localized())
+						}
 					}
-					state = .creatingRule
-				} label: {
-					Image(systemName: "plus")
+					.font(.headline.weight(.semibold))
+					.foregroundStyle(Color.softAccent)
+					.accessibilityLabel((isEditingRules ? "Done" : "Edit").localized())
 				}
-				.tint(Color.softAccent)
-                .popoverTip(addFirstFilterTip, arrowEdge: .top) { _ in
-                    addFirstFilterTip.logActionTaken()
-                    state = .creatingRule
-                }
-                .task {
-                    var previousShouldDisplay = false
-                    for await shouldDisplay in addFirstFilterTip.shouldDisplayUpdates {
-                        isAddFirstFilterTipVisible = shouldDisplay
-                        if shouldDisplay {
-                            addFirstFilterTip.logShown(isFirstLaunch: launchCount <= 1)
-                        } else if previousShouldDisplay && !shouldDisplay {
-                            // 팁이 표시되었다가 닫힘 (어떤 방식으로든)
-                            AddFirstFilterTip.shownThisLaunch = true
-                        }
-                        previousShouldDisplay = shouldDisplay
-                    }
-                }
-            }
-        }
+			}
+
+			ToolbarItem(placement: .topBarTrailing) {
+				if !isEditingRules {
+					Button {
+						if isAddFirstFilterTipVisible {
+							addFirstFilterTip.logActionTaken()
+						}
+						state = .creatingRule
+					} label: {
+						Image(systemName: "plus")
+					}
+					.tint(Color.softAccent)
+					.popoverTip(addFirstFilterTip, arrowEdge: .top) { _ in
+						addFirstFilterTip.logActionTaken()
+						state = .creatingRule
+					}
+					.task {
+						var previousShouldDisplay = false
+						for await shouldDisplay in addFirstFilterTip.shouldDisplayUpdates {
+							isAddFirstFilterTipVisible = shouldDisplay
+							if shouldDisplay {
+								addFirstFilterTip.logShown(isFirstLaunch: launchCount <= 1)
+							} else if previousShouldDisplay && !shouldDisplay {
+								// 팁이 표시되었다가 닫힘 (어떤 방식으로든)
+								AddFirstFilterTip.shownThisLaunch = true
+							}
+							previousShouldDisplay = shouldDisplay
+						}
+					}
+				}
+			}
+		}
         .tipViewStyle(AccentTipViewStyle())
-        .onChange(of: rules.count) { oldValue, newValue in
-            // 필터 개수에 따라 팁 표시 조건 업데이트
-            Task { @MainActor in
+		.onChange(of: rules.count) { oldValue, newValue in
+			if newValue == 0 {
+				isEditingRules = false
+			}
+			// 필터 개수에 따라 팁 표시 조건 업데이트
+			Task { @MainActor in
                 AddFirstFilterTip.hasFilters = !rules.isEmpty
             }
         }
@@ -387,13 +424,30 @@ struct RecipientRuleListScreen: View {
         } message: {
             Text("Permission required to acess contacts for creating recipients list".localized())
         }
-        .alert("Warning".localized(), isPresented: $showingNoContactsAlert) {
-            Button("OK".localized(), role: .cancel) { }
-        } message: {
-            Text("There is no contact matched to the enabled rules".localized())
-        }
-        .navigationDestination(item: $selectedRule) { rule in
-            RuleDetailScreen(rule: rule)
+		.alert("Warning".localized(), isPresented: $showingNoContactsAlert) {
+			Button("OK".localized(), role: .cancel) { }
+		} message: {
+			Text("There is no contact matched to the enabled rules".localized())
+		}
+		.confirmationDialog(
+			"rule.delete.confirmation.title".localized(),
+			isPresented: $showingDeleteRuleConfirmation,
+			titleVisibility: .visible
+		) {
+			Button("Delete".localized(), role: .destructive) {
+				if let rule = rulePendingDeletion {
+					deleteRule(rule)
+				}
+				rulePendingDeletion = nil
+			}
+			Button("Cancel".localized(), role: .cancel) {
+				rulePendingDeletion = nil
+			}
+		} message: {
+			Text("rule.delete.confirmation.message".localized())
+		}
+		.navigationDestination(item: $selectedRule) { rule in
+			RuleDetailScreen(rule: rule)
         }
     }
 
@@ -402,9 +456,14 @@ struct RecipientRuleListScreen: View {
         try? modelContext.save()
     }
 
-    private func deleteRule(_ rule: RecipientsRule) {
-        viewModel.deleteRule(rule, modelContext: modelContext)
-    }
+	private func deleteRule(_ rule: RecipientsRule) {
+		viewModel.deleteRule(rule, modelContext: modelContext)
+	}
+
+	private func requestDeleteRule(_ rule: RecipientsRule) {
+		rulePendingDeletion = rule
+		showingDeleteRuleConfirmation = true
+	}
 
     private func onSendMessage(allowAll: Bool = false) {
         // 규칙이 설정되었는지 확인


### PR DESCRIPTION
## Goal and success criteria
- Make Rule List deletion discoverable without relying only on long press.
- Preserve normal-mode behavior: toggle, card tap to edit, Add, Native Ad, and Send CTA.

## What changed
- Added a toolbar edit mode for the rule list.
- Normal mode toolbar leading item shows `Edit`.
- Edit mode toolbar leading item shows a checkmark icon.
- Rule rows replace the trailing toggle with a remove button in edit mode.
- Delete action uses a confirmation dialog before removing the rule.
- Add button and Send CTA are hidden in edit mode.
- Native Ad remains visible in edit mode.
- Long-press delete remains available in normal mode.

## User flow

```mermaid
flowchart TD
  A[Rule List normal mode] --> B[Tap Edit]
  B --> C[Edit mode]
  C --> D[Row toggle becomes remove button]
  D --> E[Tap remove]
  E --> F[Confirm delete]
  F -->|Delete| G[Remove rule]
  F -->|Cancel| C
  C --> H[Tap checkmark]
  H --> A
```

## Verification
- [x] xcodebuild -workspace sendadv.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build 2>&1 | xcsift -f toon -w
- [x] mise x -- tuist build 2>&1 | xcsift -f toon -w

## Notes
- Native Ad remains visible during edit mode as requested.
- No data model changes or migrations.
- `design/` source bundle is intentionally not included.

## Rollback
- Revert this PR. No data migration is involved.

## Result
<img width="390" height="305" alt="스크린샷 2026-06-30 오전 11 25 58" src="https://github.com/user-attachments/assets/7bff95ea-f7b8-45b5-a7ed-1e7d436e7b2f" />
