### PR TITLE
fix: hide rule status on empty list

### DIFF
--- a/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
@@ -119,8 +119,10 @@ struct RecipientRuleListScreen: View {
 
 			ScrollView {
 				LazyVStack(spacing: 12) {
-					RuleListStatusView(enabledCount: enabledRuleCount)
-						.padding(.bottom, 0)
+					if !rules.isEmpty {
+						RuleListStatusView(enabledCount: enabledRuleCount)
+							.padding(.bottom, 0)
+					}
 
 					ForEach(rules) { rule in
 						RecipientRuleRowView(


### PR DESCRIPTION
## Goal and success criteria
- Hide the rule count/status message when the rule list is empty.
- Keep the empty state focused on the empty-state CTA.

## What changed
- Only render `RuleListStatusView` when `rules` is not empty.

## User flow

```mermaid
flowchart TD
  A[Open Rule List] --> B{Has rules?}
  B -->|No| C[Show EmptyState only]
  B -->|Yes| D[Show status message and rule cards]
```

## Verification
- [x] xcodebuild -workspace sendadv.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build 2>&1 | xcsift -f toon -w

## Rollback
- Revert this PR. No data migration is involved.

## Result
<img width="408" height="230" alt="스크린샷 2026-06-30 오후 2 51 58" src="https://github.com/user-attachments/assets/d65fd1f2-7d0a-49f9-a88b-e5bbbe6ca37c" />
