### PR TITLE
feat: refresh empty state design

### DIFF
--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -55,7 +55,7 @@
 "rule.row.allContacts" = "All Contacts";
 "rules.empty" = "There are no contact filters";
 "rules.empty.description" = "Try adding a new contact filter";
-"rules.empty.cta" = "+ Add First Filter";
+"rules.empty.cta" = "Add your first filter";
 "rules.title" = "Contact Filter List";
 "rules.add" = "Add New Filter";
 "rules.header.title" = "Your filters";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -44,7 +44,7 @@
 "rule.row.allContacts" = "모든 연락처";
 "rules.empty" = "연락처 필터가 없습니다";
 "rules.empty.description" = "새로운 연락처 필터를 추가해보세요";
-"rules.empty.cta" = "+ 첫 번째 필터 추가";
+"rules.empty.cta" = "첫 번째 필터 추가";
 "rules.title" = "연락처 필터 목록";
 "rules.add" = "새 필터 추가";
 "rules.header.title" = "내 필터";

--- a/Projects/App/Sources/Views/RecipientComponents.swift
+++ b/Projects/App/Sources/Views/RecipientComponents.swift
@@ -15,36 +15,54 @@ struct EmptyStateView: View {
 	let onAddTapped: () -> Void
 
 	var body: some View {
-		VStack(spacing: 22) {
+		VStack(spacing: 0) {
 			ZStack {
-				Circle()
-					.fill(Color.softAccent.opacity(0.12))
-					.frame(width: 92, height: 92)
+				RoundedRectangle(cornerRadius: 40, style: .continuous)
+					.fill(Color.softSurface)
+					.frame(width: 128, height: 128)
+					.shadow(color: Color.softAccent.opacity(0.14), radius: 40, x: 0, y: 14)
 
-				Image(systemName: "person.crop.circle.badge.plus")
-					.font(.system(size: 42, weight: .semibold))
+				Image(systemName: "person.2")
+					.font(.system(size: 58, weight: .medium))
 					.foregroundStyle(Color.softAccent)
+
+				Circle()
+					.fill(Color.dynamic(light: "#E8895B", dark: "#E8A07B"))
+					.frame(width: 38, height: 38)
+					.shadow(color: Color.dynamic(light: "#E8895B", dark: "#000000").opacity(0.4), radius: 16, x: 0, y: 6)
+					.overlay {
+						Image(systemName: "plus")
+							.font(.system(size: 19, weight: .bold))
+							.foregroundStyle(Color.dynamic(light: "#FFFFFF", dark: "#1A1320"))
+					}
+					.offset(x: 58, y: -58)
 			}
 
 			Text("rules.empty".localized())
-				.font(.title2.weight(.bold))
+				.font(.system(size: 22, weight: .bold, design: .rounded))
 				.foregroundStyle(Color.softPrimaryText)
+				.padding(.top, 30)
 
 			Text("rules.empty.description".localized())
-				.font(.body)
+				.font(.system(size: 15, weight: .regular, design: .rounded))
 				.foregroundStyle(Color.softSecondaryText)
 				.multilineTextAlignment(.center)
-				.padding(.horizontal, 12)
+				.lineSpacing(4)
+				.padding(.top, 10)
 
 			Button(action: onAddTapped) {
-				Text("rules.empty.cta".localized())
+				HStack(spacing: 9) {
+					Image(systemName: "plus")
+						.font(.system(size: 16.5, weight: .bold))
+					Text("rules.empty.cta".localized())
+				}
 			}
 			.buttonStyle(SoftFriendlyPrimaryButtonStyle())
+			.frame(maxWidth: 286)
+			.padding(.top, 30)
 		}
-		.padding(28)
-		.frame(maxWidth: 340)
-		.softFriendlyCard()
-		.padding(.horizontal, 24)
+		.padding(.horizontal, 36)
+		.frame(maxWidth: .infinity)
 	}
 }
 

--- a/design.md
+++ b/design.md
@@ -128,7 +128,8 @@ Current app file candidates:
 
 Design requirements:
 - Replace the current plain list look with warm background and rounded cards.
-- Use an in-screen custom header instead of the default large navigation title.
+- Use the system Navigation Bar for the screen title/action after the navigation-bar migration.
+- Keep only the status copy inside the content area when filters exist.
 - Prefer `ScrollView` + `LazyVStack` over `List` for this screen to avoid system list insets and to match the prototype spacing.
 - Header copy should communicate status:
   - Example: `Your filters`
@@ -152,14 +153,29 @@ Design requirements:
   - no leading `Spacer()` before the gift button
   - CTA button background should fill the remaining width exactly; avoid adding horizontal padding after `frame(maxWidth: .infinity)`.
 - Empty state should be centered and friendly:
-  - large rounded illustration container
+  - Source reference: `SendAdv Soft Friendly.dc.html` `<!-- L0 Empty state (light) -->` and `<!-- D0 Empty state (dark) -->`
+  - No extra surrounding card around the empty content.
+  - Centered content around mid-screen.
+  - 128×128 rounded-square illustration container, radius 40 pt.
+  - Main icon uses people/contact grouping metaphor with accent color.
+  - Small peach/dark-peach plus badge overlaps top-right of the illustration.
   - title: `No filters yet`
+    - font: 22 pt, weight 700
+    - top margin from icon: 30 pt
   - helper text explaining grouping by job/department/organization
+    - font: 15 pt
+    - secondary color
+    - line height about 1.55
+    - top margin from title: 10 pt
   - primary CTA: `Add your first filter`
+    - plus icon + text
+    - 54 pt height capsule
+    - horizontal padding about 30 pt
+    - top margin from helper: 30 pt
 
 Implementation notes from first-screen iteration:
 - Initial `design.md` interpretation was too chip/card-oriented. The actual first-screen prototype is:
-  - large custom header,
+  - large rule-list title (now implemented using Navigation Bar),
   - large rounded filter cards,
   - left icon tile + title/subtitle + right toggle,
   - bottom fixed reward button + fill-width send pill.


### PR DESCRIPTION
## Goal and success criteria
- Refresh the empty Rule List state to match the Soft Friendly design.
- Keep the empty-state CTA behavior unchanged.

## What changed
- Replaced the old small card empty state with a centered Soft Friendly illustration layout.
- Added the large rounded-square people icon and overlapping plus badge.
- Updated title/helper/CTA spacing and typography.
- Updated CTA copy to avoid duplicate plus text now that the button includes a plus icon.
- Updated design.md with the empty-state source/design notes and navigation bar migration note.

## User flow

```mermaid
flowchart TD
  A[Open Rule List with no filters] --> B[Show Soft Friendly empty state]
  B --> C[Tap Add first filter CTA]
  C --> D[Open Rule Detail for new filter]
```

## Verification
- [x] xcodebuild -workspace sendadv.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build 2>&1 | xcsift -f toon -w
- [x] mise x -- tuist build 2>&1 | xcsift -f toon -w
- [x] Manual visual check against supplied empty-state screenshot

## Notes
- `design/` source bundle is intentionally not included.
- No persistence or navigation behavior changed.

## Rollback
- Revert this PR. No data migration is involved.

## Result
<img width="1242" height="2688" alt="Simulator Screenshot - iPhone 11 Pro Max - 2026-06-30 at 15 35 14" src="https://github.com/user-attachments/assets/c6433255-202f-4051-b445-a9bb4533b9f3" />
