### PR TITLE
fix: show send confirmation before messages

### DIFF
--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -45,6 +45,15 @@
 "send.action.with.count" = "Send to %d people";
 "send.warning.batchSending" = "You are about to send message to %d recipients.\nRecipients will be separated into groups of %d for sending.";
 "send.batch.progress" = "(Batch %d/%d — %d recipients)";
+"send.confirmation.title" = "Ready to send?";
+"send.confirmation.message" = "We'll open Messages with these %d recipients from your active filters. You can review before sending.";
+"send.confirmation.message.prefix" = "We'll open Messages with these ";
+"send.confirmation.message.count" = "%d recipients";
+"send.confirmation.message.suffix" = " from your active filters. You can review before sending.";
+"send.confirmation.openMessages" = "Open Messages";
+"send.confirmation.notNow" = "Not now";
+"send.unavailable.title" = "Messages Unavailable";
+"send.unavailable.message" = "This device cannot send SMS messages. Please try again on an iPhone with Messages available.";
 
 // Success popup (review request after 5 sends)
 "success.popup.title" = "Congratulations!";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -39,6 +39,15 @@
 
 "Select All" = "모두";
 "New Rule" = "새 필터";
+"send.confirmation.title" = "전송할까요?";
+"send.confirmation.message" = "활성화된 필터의 수신자 %d명으로 메시지 앱을 엽니다. 보내기 전에 확인할 수 있어요.";
+"send.confirmation.message.prefix" = "활성화된 필터의 ";
+"send.confirmation.message.count" = "%d명의 수신자";
+"send.confirmation.message.suffix" = "로 메시지 앱을 엽니다. 보내기 전에 확인할 수 있어요.";
+"send.confirmation.openMessages" = "메시지 열기";
+"send.confirmation.notNow" = "나중에";
+"send.unavailable.title" = "메시지를 보낼 수 없음";
+"send.unavailable.message" = "이 기기에서는 SMS 메시지를 보낼 수 없습니다. 메시지 앱을 사용할 수 있는 iPhone에서 다시 시도해 주세요.";
 
 // RecipientRuleListScreen
 "rule.row.allContacts" = "모든 연락처";

--- a/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
+++ b/Projects/App/Sources/Screens/RecipientList/RecipientRuleListScreen.swift
@@ -61,6 +61,7 @@ struct RecipientRuleListScreen: View {
     @State private var selectedRule: RecipientsRule?
 
     @State private var showingMessageComposer = false
+    @State private var showingSendConfirmationSheet = false
     @State private var isPreparingMessageView = false
 	@State private var isMessageComposerLoading = false
     @State private var showingAlert = false
@@ -79,6 +80,7 @@ struct RecipientRuleListScreen: View {
 	@State private var isEditingRules = false
 	@State private var rulePendingDeletion: RecipientsRule?
 	@State private var showingDeleteRuleConfirmation = false
+	@State private var showingMessageUnavailableAlert = false
 	    private let batchSize: Int = 20
 	    private let addFirstFilterTip = AddFirstFilterTip()
 	    @State private var isAddFirstFilterTipVisible = false
@@ -311,6 +313,17 @@ struct RecipientRuleListScreen: View {
 				}
 			}
         }
+		.sheet(isPresented: $showingSendConfirmationSheet) {
+			SendConfirmationSheet(
+				recipientCount: viewModel.phoneNumbers.count,
+				batchProgressText: batchProgressText,
+				onCancel: cancelSendConfirmation,
+				onContinue: continueFromSendConfirmation
+			)
+			.presentationDetents([.height(392)])
+			.presentationDragIndicator(.visible)
+			.presentationBackground(Color.softSurface)
+		}
 		.onChange(of: messageComposerState) {
             guard messageComposerState != .unknown else {
                 return
@@ -448,6 +461,11 @@ struct RecipientRuleListScreen: View {
 		} message: {
 			Text("rule.delete.confirmation.message".localized())
 		}
+		.alert("send.unavailable.title".localized(), isPresented: $showingMessageUnavailableAlert) {
+			Button("OK".localized(), role: .cancel) { }
+		} message: {
+			Text("send.unavailable.message".localized())
+		}
 		.navigationDestination(item: $selectedRule) { rule in
 			RuleDetailScreen(rule: rule)
         }
@@ -505,8 +523,7 @@ struct RecipientRuleListScreen: View {
 				} else {
 					// 소량이면 단일 표시
 					viewModel.phoneNumbers = phoneNumbers
-					isMessageComposerLoading = true
-					showingMessageComposer = true
+					presentSendConfirmation()
 				}
             } catch let sendMessageError as SendError {
                 switch sendMessageError {
@@ -538,10 +555,48 @@ struct RecipientRuleListScreen: View {
 		let currentNumber = currentBatchIndex + 1
 		batchProgressText = String(format: "send.batch.progress".localized(), currentNumber, totalBatches, batch.count)
 		viewModel.phoneNumbers = batch
-		isMessageComposerLoading = true
-		showingMessageComposer = true
+		presentSendConfirmation()
 		currentBatchIndex += 1
 		return false
+	}
+
+	private func presentSendConfirmation() {
+		isMessageComposerLoading = false
+		showingMessageComposer = false
+		showingSendConfirmationSheet = true
+	}
+
+	private func cancelSendConfirmation() {
+		showingSendConfirmationSheet = false
+		isBatchSending = false
+		allPhoneNumbers = []
+		currentBatchIndex = 0
+		batchProgressText = ""
+	}
+
+	private func continueFromSendConfirmation() {
+		showingSendConfirmationSheet = false
+		Task { @MainActor in
+			try? await Task.sleep(for: .milliseconds(250))
+			presentMessageComposer()
+		}
+	}
+
+	@discardableResult private func presentMessageComposer() -> Bool {
+		guard MFMessageComposeViewController.canSendText() else {
+			isBatchSending = false
+			allPhoneNumbers = []
+			currentBatchIndex = 0
+			batchProgressText = ""
+			isMessageComposerLoading = false
+			showingMessageComposer = false
+			showingMessageUnavailableAlert = true
+			return false
+		}
+
+		isMessageComposerLoading = true
+		showingMessageComposer = true
+		return true
 	}
 }
 
@@ -554,6 +609,76 @@ private struct RuleListStatusView: View {
 			.font(.title3.weight(.bold))
 			.foregroundStyle(Color.softSecondaryText)
 		.frame(maxWidth: .infinity, alignment: .leading)
+	}
+}
+
+private struct SendConfirmationSheet: View {
+	let recipientCount: Int
+	let batchProgressText: String
+	let onCancel: () -> Void
+	let onContinue: () -> Void
+
+	var body: some View {
+		VStack(alignment: .leading, spacing: 26) {
+			Image(systemName: "bubble.left")
+				.font(.system(size: 42, weight: .regular))
+				.foregroundStyle(Color.softAccent)
+				.frame(width: 104, height: 104)
+				.background(Color.softAccent.opacity(0.11), in: .rect(cornerRadius: 31, style: .continuous))
+
+			VStack(alignment: .leading, spacing: 14) {
+				Text("send.confirmation.title".localized())
+					.font(.system(size: 31, weight: .bold, design: .rounded))
+					.foregroundStyle(Color.softPrimaryText)
+
+				confirmationMessage
+					.font(.system(size: 20, weight: .semibold, design: .rounded))
+					.foregroundStyle(Color.softSecondaryText)
+					.multilineTextAlignment(.leading)
+					.lineSpacing(6)
+					.lineLimit(nil)
+					.fixedSize(horizontal: false, vertical: true)
+
+				if !batchProgressText.isEmpty {
+					Text(batchProgressText)
+						.font(.system(size: 13, weight: .bold, design: .rounded))
+						.foregroundStyle(Color.softAccent)
+						.padding(.horizontal, 14)
+						.padding(.vertical, 8)
+						.background(Color.softAccent.opacity(0.12), in: Capsule())
+				}
+			}
+
+			VStack(spacing: 10) {
+				Button(action: onContinue) {
+					HStack(spacing: 18) {
+						Image(systemName: "paperplane.fill")
+							.font(.system(size: 22, weight: .bold))
+						Text("send.confirmation.openMessages".localized())
+					}
+				}
+				.buttonStyle(SoftFriendlyPrimaryButtonStyle())
+
+				Button("send.confirmation.notNow".localized(), role: .cancel, action: onCancel)
+					.font(.system(size: 17, weight: .bold, design: .rounded))
+					.foregroundStyle(Color.softSecondaryText)
+					.frame(maxWidth: .infinity, minHeight: 44)
+			}
+			.padding(.top, 4)
+		}
+		.padding(.horizontal, 36)
+		.padding(.top, 38)
+		.padding(.bottom, 18)
+		.frame(maxWidth: .infinity, maxHeight: .infinity)
+		.background(Color.softSurface)
+	}
+
+	private var confirmationMessage: Text {
+		Text("send.confirmation.message.prefix".localized())
+			+ Text(String(format: "send.confirmation.message.count".localized(), recipientCount))
+			.foregroundStyle(Color.softAccent)
+			.fontWeight(.bold)
+			+ Text("send.confirmation.message.suffix".localized())
 	}
 }
 

--- a/Projects/App/Sources/Views/MessageComposerView.swift
+++ b/Projects/App/Sources/Views/MessageComposerView.swift
@@ -14,7 +14,16 @@ struct MessageComposerView: UIViewControllerRepresentable {
     @Binding var composeState: MessageComposeState
     @Binding var isLoading: Bool
     
-    func makeUIViewController(context: Context) -> MFMessageComposeViewController {
+    func makeUIViewController(context: Context) -> UIViewController {
+        guard MFMessageComposeViewController.canSendText() else {
+            let controller = UIViewController()
+            Task { @MainActor in
+                isLoading = false
+                composeState = .failed
+            }
+            return controller
+        }
+
         let controller = MFMessageComposeViewController()
         controller.recipients = recipients
         controller.messageComposeDelegate = context.coordinator
@@ -31,7 +40,7 @@ struct MessageComposerView: UIViewControllerRepresentable {
         return controller
     }
     
-    func updateUIViewController(_ uiViewController: MFMessageComposeViewController, context: Context) {
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
         // No update needed
     }
     


### PR DESCRIPTION
## Summary
- Add a Soft Friendly “Ready to send?” sheet before opening Messages
- Move `MFMessageComposeViewController.canSendText()` check to the “Open Messages” action
- Prevent simulator crashes by showing a localized unavailable alert when Messages cannot send SMS
- Highlight the recipient count phrase in the confirmation copy

## User flow
```mermaid
flowchart TD
    A[Tap Send] --> B[Build recipient list]
    B --> C[Ready to send? sheet]
    C -->|Not now| D[Dismiss and reset send state]
    C -->|Open Messages| E{canSendText?}
    E -->|Yes| F[Open Messages composer]
    E -->|No / Simulator| G[Show Messages Unavailable alert]
```

## Verification
- `xcodebuild -workspace sendadv.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build 2>&1 | xcsift -f toon -w`
- Build passed with 0 errors

## Result
<img width="367" height="374" alt="스크린샷 2026-06-30 오후 5 43 37" src="https://github.com/user-attachments/assets/45e873b4-18ce-418f-8d44-5d1576e5c280" />
