### PR TITLE
chore: increase app open ad interval

### DIFF
--- a/Projects/App/Sources/App.swift
+++ b/Projects/App/Sources/App.swift
@@ -75,7 +75,7 @@ struct SendadvApp: App {
             adManager.prepare(openingUnit: .launch, interval: 60.0)
             #else
             adManager.prepare(interstitialUnit: .full, interval: 60.0 * 60)
-            adManager.prepare(openingUnit: .launch, interval: 60.0 * 5)
+            adManager.prepare(openingUnit: .launch, interval: 60.0 * 30)
             #endif
             adManager.canShowFirstTime = true
         }
@@ -295,4 +295,3 @@ extension SwiftUIRewardAdManager: GADRewardManagerDelegate {
         // 필요한 경우 추가 로직
     }
 }
-


### PR DESCRIPTION
## Summary
- Increase release App Open Ad interval from 5 minutes to 30 minutes
- Keep Debug App Open Ad interval at 60 seconds
- Keep Full Ad interval at 1 hour

## User flow
```mermaid
flowchart TD
    A[App returns from background] --> B{Release interval passed?}
    B -->|Before: 5 min| C[More frequent app open ad]
    B -->|Now: 30 min| D[Less frequent app open ad]
```

## Verification
- `xcodebuild -workspace sendadv.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build 2>&1 | xcsift -f toon -w`
- Build passed with 0 errors
