### PR TITLE
chore: guard release merge and screenshot overwrite

### DIFF
--- a/.github/workflows/deploy-ios.yml
+++ b/.github/workflows/deploy-ios.yml
@@ -12,6 +12,11 @@ on:
             description: 'TestFlight 변경사항'
             required: false
             default: '수정사항'
+        overwriteScreenshots:
+            description: '기존 App Store 스크린샷 삭제 후 새 스크린샷 업로드'
+            type: boolean
+            required: true
+            default: false
 
 concurrency:
   group: ${{ github.ref }}/ios/deploy
@@ -165,4 +170,4 @@ jobs:
           IOS_KEY_PATH: ${{ env.IOS_KEY_PATH }}
           IOS_IPA_PATH: ./Output/IPA/App.ipa
         run: |
-          fastlane ios upload description:'${{ github.event.inputs.body }}' isReleasing:${{ github.event.inputs.isReleasing }}
+          fastlane ios upload description:'${{ github.event.inputs.body }}' isReleasing:${{ github.event.inputs.isReleasing }} overwriteScreenshots:${{ github.event.inputs.overwriteScreenshots }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,12 @@ fastlane ios release description:'Change description' isReleasing:false
 fastlane ios release description:'Change description' isReleasing:true
 ```
 
+### Release Merge Safety
+- **NEVER merge release/version bump PRs before App Store submission is approved by the user.**
+- Treat "ready to submit App Store" or "submit to App Store" as approval to run the App Store submission workflow only, not approval to merge release PRs.
+- App Store submission approval and GitHub PR merge approval are separate gates; ask for explicit merge approval after submission/approval status is confirmed.
+- If unsure, stop and ask before running `gh pr merge`, `git merge`, or any equivalent merge operation.
+
 ## Project Architecture
 
 **Send Multi SMS**: An iOS app for sending bulk SMS messages to multiple recipients. Users create contact filters (based on department, position, organization) to organize and manage recipient lists.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -117,6 +117,7 @@ platform :ios do
 
     isReleasing = options[:isReleasing] || false
     changelog = options[:description] || 'build from fastlane'
+    overwriteScreenshots = options[:overwriteScreenshots] || false
 
     if isReleasing
         puts "iOS 심사 업로드 시작"
@@ -127,6 +128,8 @@ platform :ios do
           submit_for_review: true,
           force: true,
           skip_screenshots: false,
+          overwrite_screenshots: overwriteScreenshots,
+          screenshots_path: "./fastlane/screenshots",
           run_precheck_before_submit: false,
         )
         puts "iOS 심사 제출 완료"


### PR DESCRIPTION
## Summary
- Add an explicit workflow option to overwrite App Store screenshots only when screenshots were updated
- Pass the option through to Fastlane as `overwrite_screenshots` with the fastlane screenshots path
- Document that App Store submission approval and release PR merge approval are separate gates

## Verification
- `ruby -c fastlane/Fastfile`

## Flow
```mermaid
flowchart TD
  A[Manual deploy workflow] --> B{isReleasing?}
  B -- false --> C[TestFlight upload]
  B -- true --> D{overwriteScreenshots?}
  D -- false --> E[Submit app without clearing screenshots]
  D -- true --> F[Clear existing App Store screenshots]
  F --> G[Upload screenshots from fastlane/screenshots]
  E --> H[Submit for App Review]
  G --> H
```
