### PR TITLE
chore(deps): update kakao-ios-sdk and LSExtensions

### DIFF
--- a/Projects/ThirdParty/Project.swift
+++ b/Projects/ThirdParty/Project.swift
@@ -5,11 +5,11 @@ let project = Project(
     name: "ThirdParty",
     packages: [
         .remote(url: "https://github.com/kakao/kakao-ios-sdk",
-                requirement: .upToNextMajor(from: "2.27.2")),
+                requirement: .upToNextMajor(from: "2.27.3")),
         .remote(url: "https://github.com/jdg/MBProgressHUD.git",
                 requirement: .upToNextMajor(from: "1.2.0")),
         .remote(url: "https://github.com/2sem/LSExtensions",
-                requirement: .exact("0.1.23")),
+                requirement: .exact("0.1.24")),
         .remote(url: "https://github.com/CosmicMind/Material",
                 requirement: .upToNextMajor(from: "3.1.8")),
         .remote(url: "https://github.com/devxoul/UITextView-Placeholder",


### PR DESCRIPTION
## Summary

Applies the non-Firebase half of #168 — Firebase is intentionally excluded.

- `kakao-ios-sdk` 2.27.2 → 2.27.3
- `LSExtensions` 0.1.23 → 0.1.24 (exact pin)
- `firebase-ios-sdk` left at 12.11.0

All changes are in `Projects/ThirdParty/Project.swift`.

## Why split from #168

#168 bundles a Firebase 12.11.0 → 12.13.0 bump with these two. A Firebase bump in this workspace touches the DynamicThirdParty dynamic wrapper and carries linker risk from binary XCFrameworks, so it is kept as a separate change to keep this one low-risk and easy to revert.

## Verification

Run locally on Tuist 4.203.0:

- `mise x -- tuist install` → plugins resolved and fetched successfully
- `mise x -- tuist generate --no-open` → project generated, no errors
- `xcodebuild -workspace sendadv.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator build` → **success**, 0 errors, 0 linker errors, 4 warnings

## Follow-up

#168 stays open, carrying only the Firebase 12.11.0 → 12.13.0 bump once rebased onto this.
