### PR TITLE
chore(deps): upgrade firebase-ios-sdk to 12.17.0

### DIFF
--- a/Projects/App/Project.swift
+++ b/Projects/App/Project.swift
@@ -25,8 +25,10 @@ let project = Project(
         .remote(url: "https://github.com/2sem/GADManager",
                 requirement: .upToNextMajor(from: "1.4.0")),
         // .local(path: "../../../../../pods/GADManager/src/GADManager"),
-//        .remote(url: "https://github.com/firebase/firebase-ios-sdk",
-//                requirement: .upToNextMajor(from: "12.11.0")),
+        // Declared on the app target too: linking Firebase only through the
+        // DynamicThirdParty wrapper drops GoogleAppMeasurement's _APM* symbols
+        // at the app target's link step.
+        .package(id: "firebase.firebase-ios-sdk", exact: "12.17.0"),
     ],
     settings: .settings(configurations: [
         .debug(
@@ -91,16 +93,36 @@ let project = Project(
             dependencies: [
                 .Projects.ThirdParty,
                 .Projects.DynamicThirdParty,
-                .package(product: "GADManager", type: .runtime)
+                .package(product: "GADManager", type: .runtime),
+                .package(product: "FirebaseCrashlytics", type: .runtime),
+                .package(product: "FirebaseAnalytics", type: .runtime),
+                .package(product: "FirebaseMessaging", type: .runtime),
+                .package(product: "FirebaseRemoteConfig", type: .runtime),
+                // Transitive chain that does not propagate through the dynamic
+                // wrapper: FirebaseCore/Installations, GoogleUtilities submodules
+                // and nanopb all fail to resolve at the app target's link step.
+                .package(product: "FirebaseCore", type: .runtime),
+                .package(product: "FirebaseInstallations", type: .runtime),
+                .package(product: "GULAppDelegateSwizzler", type: .runtime),
+                .package(product: "GULMethodSwizzler", type: .runtime),
+                .package(product: "GULEnvironment", type: .runtime),
+                .package(product: "GULLogger", type: .runtime),
+                .package(product: "GULNSData", type: .runtime),
+                .package(product: "GULNetwork", type: .runtime),
+                .package(product: "nanopb", type: .runtime)
             ],
-            settings: .settings(configurations: [
-                .debug(
-                    name: "Debug",
-                    xcconfig: "Configs/app.debug.xcconfig"),
-                .release(
-                    name: "Release",
-                    xcconfig: "Configs/app.release.xcconfig")
-            ])
+            settings: .settings(
+                base: [
+                    "OTHER_LDFLAGS": "$(inherited) -framework GoogleAppMeasurement -framework GoogleAppMeasurementIdentitySupport"
+                ],
+                configurations: [
+                    .debug(
+                        name: "Debug",
+                        xcconfig: "Configs/app.debug.xcconfig"),
+                    .release(
+                        name: "Release",
+                        xcconfig: "Configs/app.release.xcconfig")
+                ])
         ),
         .target(
             name: "AppTests",

--- a/Projects/DynamicThirdParty/Project.swift
+++ b/Projects/DynamicThirdParty/Project.swift
@@ -4,7 +4,7 @@ import ProjectDescriptionHelpers
 let project = Project(
     name: "DynamicThirdParty",
     packages: [        .package(id: "sdwebimage.sdwebimage", from: "5.21.7"),
-                       .package(id: "firebase.firebase-ios-sdk", exact: "12.13.0"),
+                       .package(id: "firebase.firebase-ios-sdk", exact: "12.17.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary

- `firebase-ios-sdk` 12.13.0 → 12.17.0 (`Projects/DynamicThirdParty/Project.swift`, exact pin kept)
- Declare the Firebase package on the **App** target as well, not only on the `DynamicThirdParty` dynamic wrapper
- Add the transitive product chain (FirebaseCore/Installations, GoogleUtilities submodules, nanopb) to the App target
- Force-link `GoogleAppMeasurement` and `GoogleAppMeasurementIdentitySupport` via `OTHER_LDFLAGS`

## Why the extra dependencies

Bumping the version alone builds the wrapper fine but fails at the **App target's** `Ld` step. SPM does not reliably re-export a binary XCFramework's symbols through an intermediate dynamic framework, so the app binary ends up with nothing to resolve against.

Three archive runs, each clearing one layer:

| Attempt | Change | Result |
|---|---|---|
| 1 | Version bump only | `ld` — undefined `_OBJC_METACLASS_$_APM*` from `FirebaseAnalytics` |
| 2 | Firebase package + 4 high-level products + `OTHER_LDFLAGS` on App target | `_APM*` resolved; undefined `_GUL*`, `_FIR*`, `_pb_*` |
| 3 | Added `FirebaseCore`, `FirebaseInstallations`, `GULAppDelegateSwizzler`, `GULMethodSwizzler`, `GULEnvironment`, `GULLogger`, `GULNSData`, `GULNetwork`, `nanopb` | **Archive Succeeded** |

Only the products actually pulled in by the chain were added — no blanket "link everything Firebase" pass.

## Link Chain

```mermaid
flowchart TD
  A[App target] --> B[DynamicThirdParty framework]
  B --> C[FirebaseAnalytics / Crashlytics / Messaging / RemoteConfig]
  C --> D[GoogleAppMeasurement binary XCFramework]
  C --> E[GoogleUtilities submodules + nanopb]
  C --> F[FirebaseCore / FirebaseInstallations]
  D -. symbols do not re-export through the dynamic wrapper .-> A
  E -. same .-> A
  F -. same .-> A
  A --> G[Direct package deps + OTHER_LDFLAGS force-link]
  G --> D
  G --> E
  G --> F
```

## Verification

Tuist 4.203.0, `Package.resolved` shows `firebase.firebase-ios-sdk` at **12.17.0**.

- `mise x -- tuist install` → success
- `mise x -- tuist generate --no-open` → success
- `tuist xcodebuild archive -scheme App -configuration Release` → **Archive Succeeded**, 0 undefined symbols

Archive was used rather than a simulator build on purpose — these symbol drops only surface at archive/thin-link time.

## Notes

- Pre-existing warnings unrelated to this change: `DEFINES_MODULE` umbrella-header warnings, `DataMigrationManager.swift` main-actor Sendable warnings, and Firebase's own `FirebaseCore is missing a dependency on FirebaseCoreInternal`.
- Not yet run on a simulator or device — worth a smoke test that Analytics/Crashlytics still initialize at runtime before release.
