### PR TITLE
feat: pinned recipient-count bar on RuleDetailScreen (PR 1/4, #137)

### DIFF
--- a/Projects/App/Resources/Strings/en.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/en.lproj/Localizable.strings
@@ -87,6 +87,8 @@
 "Anyone" = "Anyone";
 "unsaved.changes.title" = "Save Changes?";
 "unsaved.changes.discard" = "Don't Save";
+"rule.detail.recipient.count.label" = "Estimated Recipients";
+"rule.detail.recipient.count.value" = "%d recipients";
 
 // RuleFilterScreen
 "rule.filter.helper.job" = "Pick which job titles this filter includes";

--- a/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
+++ b/Projects/App/Resources/Strings/ko.lproj/Localizable.strings
@@ -76,6 +76,8 @@
 "Anyone" = "누구나";
 "unsaved.changes.title" = "변경사항을 저장하시겠습니까?";
 "unsaved.changes.discard" = "저장 안 함";
+"rule.detail.recipient.count.label" = "예상 수신자";
+"rule.detail.recipient.count.value" = "%d명";
 
 // RuleFilterScreen
 "rule.filter.helper.job" = "이 필터에 포함할 직책을 선택하세요";

--- a/Projects/App/Sources/Controllers/SAContactController.swift
+++ b/Projects/App/Sources/Controllers/SAContactController.swift
@@ -26,41 +26,34 @@ class SAContactController : NSObject{
         CNContact.localizedString(forKey: CNLabelPhoneNumberMobile);
         
         values = try contactStore.unifiedContacts(matching: predicate, keysToFetch: keys);
-        
+
         return values;
     }
-    
+
+    /// Async wrapper around `loadAllContacts(_:)` that runs the (blocking) address book fetch
+    /// off the main actor, so `@MainActor`-isolated callers (e.g. `RuleDetailScreenModel`) don't
+    /// block the UI thread while `CNContactStore` walks the default container.
+    func loadAllContactsAsync(_ keys: [CNKeyDescriptor] = [CNContactFormatter.descriptorForRequiredKeys(for: .fullName), CNContactNameSuffixKey as CNKeyDescriptor, CNContactDepartmentNameKey as CNKeyDescriptor, CNContactJobTitleKey as CNKeyDescriptor, CNContactOrganizationNameKey as CNKeyDescriptor, CNContactPhoneNumbersKey as CNKeyDescriptor]) async throws -> [CNContact]{
+        try await Task.detached(priority: .userInitiated) { [self] in
+            try self.loadAllContacts(keys);
+        }.value;
+    }
+
     func loadContacts(rules : [RecipientsRule]) -> [String]?{
         var values : [String]! = []
         let rules = rules.filter { (rule) -> Bool in
             return rule.enabled;
         }
-        
+
         do{
             let contacts = try self.loadAllContacts();
-            
+
             NSLog("load contacts. count[\(contacts.count)]");
             for contact in contacts{
-                var mobile = "";
-                
-                //get only one mobile number for a contact
-                for phone in contact.phoneNumbers{
-                    let number = phone.value.stringValue;
-                    guard SAMobileController.Default.isMobile(phone: phone) else{
-//                    guard self.isMobileNumber(number: number, prefixes: mobilePrefixesForKor) else{
-                        continue;
-                    }
-                    
-                    if !values.contains(number){
-                        mobile = number;
-                        break;
-                    }
-                }
-                
-                if mobile.isEmpty{
+                guard let mobile = self.firstUsableMobileNumber(for: contact, excluding: values) else{
                     continue;
                 }
-                
+
                 //filter by rule
                 var needToAdd = true;
                 for rule in rules{
@@ -69,22 +62,65 @@ class SAContactController : NSObject{
                         break;
                     }
                 }
-                
+
                 guard needToAdd else{
                     continue;
                 }
-                
+
                 values.append(mobile);
             }
-            
+
             //            self.generate(contacts);
-            
+
         }catch(let error){
             NSLog("load contacts error[\(error)]");
             values = nil;
         }
-        
+
         return values;
+    }
+
+    /// Counts sendable phone numbers (one deduped mobile per contact) that match the given
+    /// filter conditions, regardless of any rule's `enabled` flag.
+    ///
+    /// Used by the recipient-count preview on `RuleDetailScreen` while a rule is being edited,
+    /// including rules that are currently disabled. Does not fetch contacts itself — pass in a
+    /// previously-loaded `[CNContact]` snapshot so repeated recounts stay in memory.
+    func recipientCount(contacts: [CNContact], filters: [RecipientsFilter]) -> Int{
+        var usedNumbers: [String] = [];
+        var count = 0;
+
+        for contact in contacts{
+            guard let mobile = self.firstUsableMobileNumber(for: contact, excluding: usedNumbers) else{
+                continue;
+            }
+
+            guard self.isMatchedContact(contact: contact, filters: filters) else{
+                continue;
+            }
+
+            usedNumbers.append(mobile);
+            count += 1;
+        }
+
+        return count;
+    }
+
+    /// Returns the first mobile number on `contact` that isn't already present in `usedNumbers`,
+    /// mirroring the dedup behavior `loadContacts(rules:)` has always used.
+    private func firstUsableMobileNumber(for contact: CNContact, excluding usedNumbers: [String]) -> String?{
+        for phone in contact.phoneNumbers{
+            let number = phone.value.stringValue;
+            guard SAMobileController.Default.isMobile(phone: phone) else{
+                continue;
+            }
+
+            if !usedNumbers.contains(number){
+                return number;
+            }
+        }
+
+        return nil;
     }
     
     func loadJobTitles() -> [String]{
@@ -138,21 +174,23 @@ class SAContactController : NSObject{
     }
     
     func isMatchedContact(contact : CNContact, rule : RecipientsRule) -> Bool{
-        var value = true;
-        let filters = rule.filters ?? [];
+        return self.isMatchedContact(contact: contact, filters: rule.filters ?? []);
+    }
 
+    /// Matches `contact` against a raw set of filter conditions, independent of any owning
+    /// rule's `enabled` flag. Shared by `isMatchedContact(contact:rule:)` and `recipientCount`.
+    func isMatchedContact(contact : CNContact, filters : [RecipientsFilter]) -> Bool{
         guard !filters.isEmpty else{
-            return value;
+            return true;
         }
         //name, nickname, jot title, department, company
         for filter in filters{
-            value = value && self.isMatchedContact(contact: contact, filter: filter);
-            if !value {
-                break;
+            guard self.isMatchedContact(contact: contact, filter: filter) else{
+                return false;
             }
         }
-        
-        return value;
+
+        return true;
     }
     
     class FilterTargetNames{
@@ -179,15 +217,12 @@ class SAContactController : NSObject{
                 break;
             case FilterTargetNames.Job:
                 value = self.isMatchedText(text: contact.jobTitle, filter: filter);
-                print("filter contract. name[\(contact.fullName ?? "")] job[\(contact.jobTitle)] => \(value)");
                 break;
             case FilterTargetNames.Department:
                 value = self.isMatchedText(text: contact.departmentName, filter: filter);
-                print("filter contract. name[\(contact.fullName ?? "")] dept[\(contact.departmentName)] => \(value)");
                 break;
             case FilterTargetNames.Organization:
                 value = self.isMatchedText(text: contact.organizationName, filter: filter);
-                print("filter contract. name[\(contact.fullName ?? "")] org[\(contact.organizationName)] => \(value)");
                 break;
             default:
                 break;

--- a/Projects/App/Sources/Screens/RuleDetailScreen.swift
+++ b/Projects/App/Sources/Screens/RuleDetailScreen.swift
@@ -71,6 +71,21 @@ struct RuleDetailScreen: View {
 					.padding(.bottom, 28)
 				}
 				.scrollIndicators(.hidden)
+
+				if case .available(let count) = viewModel.recipientCountState, count > 0 {
+					RecipientCountBar(count: count)
+				}
+			}
+		}
+		.onAppear {
+			viewModel.loadRecipientCountIfNeeded()
+		}
+		.onDisappear {
+			viewModel.cancelRecipientCountWork()
+		}
+		.onChange(of: selectedFilter) { oldValue, newValue in
+			if oldValue != nil && newValue == nil {
+				viewModel.scheduleRecipientCountRecompute()
 			}
 		}
 		.navigationTitle("rule.detail.title.new".localized())
@@ -140,6 +155,37 @@ struct RuleDetailScreen: View {
 
 	private func detailSubtitle(_ value: String) -> String {
 		value == "All".localized() ? "Anyone".localized() : value
+	}
+}
+
+/// Pinned bar showing the live count of sendable phone numbers (deduped mobiles, not raw
+/// contacts) matched by the rule's current filter conditions. Sits below the scroll content,
+/// above the safe area. Deliberately unlike `RuleFilterCategoryCard` - no corner radius, no
+/// shadow, no chevron - since it isn't tappable.
+private struct RecipientCountBar: View {
+	let count: Int
+
+	var body: some View {
+		HStack {
+			Text("rule.detail.recipient.count.label".localized())
+				.font(.system(size: 12.5, weight: .semibold, design: .rounded))
+				.foregroundStyle(Color.softSecondaryText)
+
+			Spacer()
+
+			Text(String(format: "rule.detail.recipient.count.value".localized(), count))
+				.font(.system(size: 22, weight: .bold, design: .rounded))
+				.foregroundStyle(Color.softAccent)
+				.contentTransition(.numericText())
+		}
+		.padding(.horizontal, 22)
+		.padding(.vertical, 14)
+		.background(Color.softSurface)
+		.overlay(alignment: .top) {
+			Divider()
+				.background(Color.softDivider)
+		}
+		.accessibilityElement(children: .combine)
 	}
 }
 

--- a/Projects/App/Sources/ViewModels/RuleDetailScreenModel.swift
+++ b/Projects/App/Sources/ViewModels/RuleDetailScreenModel.swift
@@ -7,12 +7,30 @@
 
 import SwiftUI
 import SwiftData
+import Contacts
 
+/// State for the pinned recipient-count bar on `RuleDetailScreen`.
+///
+/// Only `.available` is rendered with dedicated UI today. `.loading` and `.permissionDenied`
+/// exist now so the contacts-permission and loading treatments (tracked separately) can be
+/// added later without reshaping this type.
+enum RecipientCountState: Equatable {
+	case loading
+	case available(Int)
+	case permissionDenied
+}
+
+@MainActor
 @Observable
 class RuleDetailScreenModel {
 	var rule: RecipientsRule?
 	var title: String = ""
 	var isSaved: Bool = false
+	private(set) var recipientCountState: RecipientCountState = .loading
+
+	private var cachedContacts: [CNContact]?
+	private var recipientCountLoadTask: Task<Void, Never>?
+	private var recipientCountDebounceTask: Task<Void, Never>?
 
 	var hasChanges: Bool {
 		title != (rule?.title ?? "");
@@ -22,7 +40,7 @@ class RuleDetailScreenModel {
 		self.rule = rule;
 		self.title = rule?.title ?? "";
 	}
-	
+
     func save(using context: ModelContext) {
         if rule?.modelContext == nil, let rule {
             context.insert(rule)
@@ -99,5 +117,74 @@ class RuleDetailScreenModel {
 		let newFilter = RecipientsFilter(target: .init(rawValue: target), includes: nil, excludes: nil, all: true)
 		rule.filters?.append(newFilter)
 		return newFilter
+	}
+
+	// MARK: - Recipient count preview
+
+	/// Fetches the address book once (off the main actor) and computes the initial count.
+	/// Safe to call repeatedly - after the first successful fetch this just recomputes in memory.
+	func loadRecipientCountIfNeeded() {
+		guard cachedContacts == nil else {
+			recomputeRecipientCount()
+			return
+		}
+
+		guard recipientCountLoadTask == nil else {
+			return
+		}
+
+		recipientCountLoadTask = Task { [weak self] in
+			guard let self else { return }
+			do {
+				let contacts = try await SAContactController.Default.loadAllContactsAsync()
+				guard !Task.isCancelled else { return }
+				self.cachedContacts = contacts
+				self.recomputeRecipientCount()
+			} catch {
+				guard !Task.isCancelled else { return }
+				self.recipientCountState = .permissionDenied
+			}
+			self.recipientCountLoadTask = nil
+		}
+	}
+
+	/// Schedules an in-memory recount, coalescing calls that arrive within ~250ms. Filters are
+	/// only mutated by `RuleFilterScreen`, so in practice this fires once per navigation return -
+	/// the coalescing is just a safety net for rapid multi-select. Independent of
+	/// `recipientCountLoadTask` so a recompute scheduled while the initial fetch is still in
+	/// flight doesn't cancel that fetch.
+	func scheduleRecipientCountRecompute() {
+		recipientCountDebounceTask?.cancel()
+
+		recipientCountDebounceTask = Task { [weak self] in
+			try? await Task.sleep(for: .milliseconds(250))
+			guard !Task.isCancelled else { return }
+			self?.recomputeRecipientCount()
+			self?.recipientCountDebounceTask = nil
+		}
+	}
+
+	/// Cancels any in-flight fetch or coalesced recompute. Call from `onDisappear` so a slow
+	/// contacts fetch or pending debounce doesn't outlive the screen.
+	func cancelRecipientCountWork() {
+		recipientCountLoadTask?.cancel()
+		recipientCountLoadTask = nil
+		recipientCountDebounceTask?.cancel()
+		recipientCountDebounceTask = nil
+	}
+
+	/// Re-runs the (cheap, in-memory) match against the cached contacts. Never triggers a
+	/// contacts fetch or a SwiftData save - reads whatever is currently on `rule.filters`,
+	/// including in-progress, unsaved edits, and ignores `rule.enabled` since the preview
+	/// must reflect the rule being edited regardless of its enabled state.
+	private func recomputeRecipientCount() {
+		guard let contacts = cachedContacts else { return }
+
+		let filters = rule?.filters ?? []
+		let count = SAContactController.Default.recipientCount(contacts: contacts, filters: filters)
+
+		withAnimation {
+			recipientCountState = .available(count)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Adds a pinned recipient-count bar to `RuleDetailScreen`, showing sendable phone numbers (deduped mobiles, not raw contacts) matched by the rule's current filters
- Counts ignore `rule.enabled` (must reflect the rule under edit even when disabled), never trigger a SwiftData save, and only re-run in-memory matching against a contacts snapshot fetched once via `Task`/async-await (off the main actor)
- Bar animates the number with `.contentTransition(.numericText())` when returning from `RuleFilterScreen`
- Stripped per-contact debug `print`s in `SAContactController.isMatchedContact` that would otherwise flood the console on every recount
- PR 1 of 4 for #137 - only the normal (count > 0) state is implemented; `RecipientCountState` also has `.loading`/`.permissionDenied` cases so the remaining PRs (permission-denied, zero-count, loading UI) don't require rework

## Test plan
- [x] `xcodebuild -workspace sendadv.xcworkspace -scheme App -configuration Debug -sdk iphonesimulator CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" build` succeeds (0 errors, 0 new warnings)
- [ ] Manual: edit a rule, verify count matches expectations for job/dept/org filters and updates when returning from `RuleFilterScreen`
- [ ] Manual: edit a disabled rule and confirm the count is not inflated to "all contacts"

Ref #137
